### PR TITLE
✏️ Remove spelling mistakes in files that reference 'Extensions.cs'

### DIFF
--- a/Emerald.App/Emerald.App/DirectResources.cs
+++ b/Emerald.App/Emerald.App/DirectResources.cs
@@ -8,7 +8,7 @@ namespace Emerald.WinUI;
 public static class DirectResoucres
 {
     public static int MaxRAM
-        => Extentions.GetMemoryGB() * 1024;
+        => Extensions.GetMemoryGB() * 1024;
 
     public static int MinRAM
         => 512;

--- a/Emerald.App/Emerald.App/Helpers/Extensions.cs
+++ b/Emerald.App/Emerald.App/Helpers/Extensions.cs
@@ -12,7 +12,7 @@ using Windows.System.Diagnostics;
 
 namespace Emerald.WinUI.Helpers
 {
-    public static class Extentions
+    public static class Extensions
     {
         private static readonly ConcurrentDictionary<string, string> cachedResources = new();
 

--- a/Emerald.App/Emerald.App/Views/Store/InstallerPage.xaml
+++ b/Emerald.App/Emerald.App/Views/Store/InstallerPage.xaml
@@ -34,7 +34,7 @@
                             <TextBlock Text="{x:Bind Name}"/>
                             <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource ButtonDisabledForegroundThemeBrush}">
                                 <Run Text="{x:Bind Version_type,Converter={StaticResource StringToLocalString}}"/> | 
-                                <Run Text="{x:Bind helpers:Extentions.KiloFormat(Downloads)}"/> Downloads
+                                <Run Text="{x:Bind helpers:Extensions.KiloFormat(Downloads)}"/> Downloads
                             </TextBlock>
 
                             <TextBlock Visibility="{x:Bind IsDetailsVisible,Mode=OneWay,Converter={StaticResource BoolToVisibilty}}" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource ButtonDisabledForegroundThemeBrush}">

--- a/Emerald.Core/Extensions.cs
+++ b/Emerald.Core/Extensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Emerald.Core
 {
-    public static class Extentions
+    public static class Extensions
     {
         public static string ToFullVersion(this ProjBobcat.Class.Model.Optifine.OptifineDownloadVersionModel x)
             => $"{x.McVersion}-Optifine_{x.Type}_{x.Patch}";


### PR DESCRIPTION
<!--⏱️ Before you start...
Have you checked whether or not a similar pull request has already been reported?-->

### 📄 Description
<!--A clear and concise description of what your idea is. Include things like possible use cases, drawbacks, etc.-->

Remove incorrectly spelt 'Extentions' in favour of 'Extensions', the correctly spelt alternative. First noticed in #19 but never resolved.

### ✅ Tasks
<!--Give an overview of all the specific things you would like to be changed or implemented.
If an issue already exists with this, you can add the issue link or number-->

```[tasklist]
### Remove 'Extentions' and all its references
- [x] Remove all references to the word 'Extentions'
- [ ] Reference 'Extentions.cs' in project/other required references
- [ ] Replace filenames including 'Extentions' with 'Extensions'
```
