### PR TITLE
Upload .cer and with appxbundle with Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,30 +347,16 @@ jobs:
             -SkipBundleArchive `
             -CertificatePath $env:EMERALD_SIGNING_CERT_PATH
 
-      - name: Upload CI appxbundle artifact
+      - name: Upload CI Windows package artifact
         uses: actions/upload-artifact@v4
         with:
           name: Emerald-Windows-AppxBundle
-          path: ${{ github.workspace }}/artifacts/windows/final/Emerald-Windows-Signed-x64-arm64.appxbundle
-          retention-days: 14
-
-      - name: Upload Windows release files to draft release
-        if: ${{ needs.ci-filter.outputs.is_release_flow == 'true' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.ci-filter.outputs.release_tag }}
-          name: Emerald ${{ needs.ci-filter.outputs.public_version }}
-          target_commitish: ${{ github.sha }}
-          draft: true
-          prerelease: ${{ needs.ci-filter.outputs.release_is_prerelease == 'true' }}
-          make_latest: ${{ needs.ci-filter.outputs.release_channel == 'release' }}
-          generate_release_notes: false
-          files: |
+          path: |
             ${{ github.workspace }}/artifacts/windows/final/*.msixbundle
             ${{ github.workspace }}/artifacts/windows/final/*.appxbundle
             ${{ github.workspace }}/artifacts/windows/final/*.msix
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ${{ github.workspace }}/artifacts/windows/final/*.cer
+          retention-days: 14
 
       - name: Cleanup signing certificate
         if: always()
@@ -514,6 +500,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Emerald-Windows-AppxBundle
+          path: release-assets/windows
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
         with:

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -20,13 +20,15 @@ pwsh ./scripts/windows/publish-windows-msix.ps1 `
   -CertificatePassword $certPassword
 ```
 
-Output archive:
+Output files:
 
-- `artifacts/windows/final/Emerald-Windows-Signed-x64-arm64.zip`
+- `artifacts/windows/final/Emerald-Windows-Signed-x64-arm64.appxbundle`
+- `artifacts/windows/final/Emerald-Windows-Signing.cer`
+- `artifacts/windows/final/Emerald-Windows-Signed-x64-arm64.zip` when archive creation is enabled
 
 ## Trust and install
 
-For sideload install on Windows, import the public cert first:
+For sideload install on Windows, import the public cert first. CI artifacts and draft releases now include the exported `.cer` alongside the Windows package:
 
 ```powershell
 Import-Certificate -FilePath "C:\secrets\EmeraldSigning.cer" -CertStoreLocation "Cert:\LocalMachine\TrustedPeople"

--- a/scripts/windows/publish-windows-msix.ps1
+++ b/scripts/windows/publish-windows-msix.ps1
@@ -319,6 +319,7 @@ try {
     $platformSlug = ($Platforms -join "-")
     $bundlePath = Join-Path $bundleOutput "Emerald-Windows-Signed-$platformSlug.msixbundle"
     $appxBundlePath = Join-Path $bundleOutput "Emerald-Windows-Signed-$platformSlug.appxbundle"
+    $publicCertificatePath = Join-Path $bundleOutput "Emerald-Windows-Signing.cer"
     & $makeAppx bundle /o /d $bundleInput /p $bundlePath /bv $Version
 
     if ($LASTEXITCODE -ne 0) {
@@ -356,10 +357,15 @@ try {
     Write-Step "Signed bundle created: $bundlePath"
     Copy-Item -LiteralPath $bundlePath -Destination $appxBundlePath -Force
     Write-Step "Appx-compatible bundle copy created: $appxBundlePath"
+    [System.IO.File]::WriteAllBytes(
+        $publicCertificatePath,
+        $importedCert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+    Write-Step "Public signing certificate exported: $publicCertificatePath"
 
     if ($env:GITHUB_OUTPUT) {
         Add-Content -Path $env:GITHUB_OUTPUT -Value "windows_bundle_path=$bundlePath"
         Add-Content -Path $env:GITHUB_OUTPUT -Value "windows_appxbundle_path=$appxBundlePath"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "windows_signing_certificate_path=$publicCertificatePath"
         if (-not $SkipBundleArchive) {
             Add-Content -Path $env:GITHUB_OUTPUT -Value "windows_zip_path=$zipPath"
         }


### PR DESCRIPTION
Update CI to upload Windows package artifacts as a set (*.msixbundle, *.appxbundle, *.msix) plus the exported public cert (*.cer) and apply a 14-day retention.
