### PR TITLE
Add Ely.by account support and auth providers

### DIFF
--- a/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
+++ b/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
@@ -15,90 +15,109 @@ namespace Emerald.CoreX.Tests.Services;
 public sealed class AccountServiceTests
 {
     [Fact]
-    public void RequireMicrosoftAccountForOfflineAccounts_IsEnabled()
+    public void RequireMicrosoftAccountForOfflineAccounts_IsDisabled()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
 
-        Assert.True(service.RequireMicrosoftAccountForOfflineAccounts);
+        Assert.False(service.RequireMicrosoftAccountForOfflineAccounts);
     }
 
     [Fact]
-    public void RequireMicrosoftAccountForElyByAccounts_IsEnabled()
+    public void RequireMicrosoftAccountForElyByAccounts_IsDisabled()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
 
-        Assert.True(service.RequireMicrosoftAccountForElyByAccounts);
+        Assert.False(service.RequireMicrosoftAccountForElyByAccounts);
     }
 
     [Fact]
-    public void CreateOfflineAccount_WithoutMicrosoftAccount_Throws()
+    public void CreateOfflineAccount_WithoutMicrosoftAccount_CreatesAccount()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
 
-        var exception = Assert.Throws<InvalidOperationException>(() => service.CreateOfflineAccount("Alpha"));
+        service.CreateOfflineAccount("Alpha");
 
-        Assert.Equal("Creating offline accounts requires at least one Microsoft account.", exception.Message);
+        Assert.Contains(service.Accounts, account => account.Type == AccountType.Offline && account.Name == "Alpha");
     }
 
     [Fact]
-    public void SetSelectedAccount_OfflineWithoutMicrosoftAccount_Throws()
-    {
-        var service = CreateService(new InMemoryBaseSettingsService());
-        var offline = new EAccount("Alpha", AccountType.Offline);
-        service.Accounts.Add(offline);
-
-        var exception = Assert.Throws<InvalidOperationException>(() => service.SetSelectedAccount(offline));
-
-        Assert.Equal("Selecting an offline account requires at least one Microsoft account.", exception.Message);
-        Assert.Null(service.GetSelectedAccount());
-    }
-
-    [Fact]
-    public async Task AuthenticateAccountAsync_OfflineWithoutMicrosoftAccount_Throws()
+    public void SetSelectedAccount_OfflineWithoutMicrosoftAccount_SelectsAccount()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
         var offline = new EAccount("Alpha", AccountType.Offline);
         service.Accounts.Add(offline);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.AuthenticateAccountAsync(offline));
+        service.SetSelectedAccount(offline);
 
-        Assert.Equal("Offline accounts require at least one Microsoft account.", exception.Message);
+        Assert.Same(offline, service.GetSelectedAccount());
     }
 
     [Fact]
-    public async Task SignInElyByAccountAsync_WithoutMicrosoftAccount_Throws()
+    public async Task AuthenticateAccountAsync_OfflineWithoutMicrosoftAccount_Authenticates()
     {
-        var service = CreateServiceWithEly(new InMemoryBaseSettingsService());
+        var service = CreateService(new InMemoryBaseSettingsService());
+        var offline = new EAccount("Alpha", AccountType.Offline);
+        service.Accounts.Add(offline);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.SignInElyByAccountAsync("ely@example.com", "password"));
+        var result = await service.AuthenticateAccountAsync(offline);
 
-        Assert.Equal("Signing in with Ely.by requires at least one Microsoft account.", exception.Message);
+        Assert.Equal("Alpha", result.Session.Username);
     }
 
     [Fact]
-    public void SetSelectedAccount_ElyByWithoutMicrosoftAccount_Throws()
+    public async Task SignInElyByAccountAsync_WithoutMicrosoftAccount_UsesBrowserOAuth()
+    {
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        var elyByClient = new FakeElyByAuthClient();
+        var oauthBrowser = new FakeElyByOAuthBrowser();
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient, elyByOAuthBrowser: oauthBrowser);
+
+        await service.SignInElyByAccountAsync();
+
+        Assert.Single(oauthBrowser.Requests);
+        Assert.Equal(["ely-oauth-code"], elyByClient.ExchangeOAuthCodeCalls);
+        Assert.Contains(service.Accounts, account => account.Type == AccountType.ElyBy && account.Name == "ElyOAuthPlayer");
+    }
+
+    [Fact]
+    public void SetSelectedAccount_ElyByWithoutMicrosoftAccount_SelectsAccount()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
         var elyBy = new EAccount("ElyAlpha", AccountType.ElyBy, "ely-alpha-uuid", "elyby:ely-alpha-uuid");
         service.Accounts.Add(elyBy);
 
-        var exception = Assert.Throws<InvalidOperationException>(() => service.SetSelectedAccount(elyBy));
+        service.SetSelectedAccount(elyBy);
 
-        Assert.Equal("Selecting an Ely.by account requires at least one Microsoft account.", exception.Message);
-        Assert.Null(service.GetSelectedAccount());
+        Assert.Same(elyBy, service.GetSelectedAccount());
     }
 
     [Fact]
-    public async Task AuthenticateAccountAsync_ElyByWithoutMicrosoftAccount_Throws()
+    public async Task AuthenticateAccountAsync_ElyByWithoutMicrosoftAccount_Authenticates()
     {
-        var service = CreateService(new InMemoryBaseSettingsService());
-        var elyBy = new EAccount("ElyAlpha", AccountType.ElyBy, "ely-alpha-uuid", "elyby:ely-alpha-uuid");
-        service.Accounts.Add(elyBy);
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        baseSettingsService.Set(
+            SettingsKeys.ElyByAccounts,
+            new List<ElyByStoredAccount>
+            {
+                new()
+                {
+                    UniqueId = "elyby:ely-alpha-uuid",
+                    Name = "ElyAlpha",
+                    UUID = "ely-alpha-uuid",
+                    AccessToken = "ely-access",
+                    ClientToken = "ely-client",
+                    LastUsed = DateTime.UtcNow.AddHours(-1)
+                }
+            });
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.AuthenticateAccountAsync(elyBy));
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: new FakeElyByAuthClient());
+        await service.InitializeAsync("client-id");
+        await service.LoadAllAccountsAsync();
 
-        Assert.Equal("Ely.by accounts require at least one Microsoft account.", exception.Message);
+        var elyBy = Assert.Single(service.Accounts, account => account.Type == AccountType.ElyBy);
+        var result = await service.AuthenticateAccountAsync(elyBy);
+
+        Assert.Equal("ElyAlpha", result.Session.Username);
     }
 
     [Fact]
@@ -220,18 +239,25 @@ public sealed class AccountServiceTests
     }
 
     [Fact]
-    public async Task SignInElyByAccountAsync_AddsStoredAccount_AndSelectsWhenNoSelectionExists()
+    public async Task SignInElyByAccountAsync_AddsOAuthStoredAccount_AndSelectsWhenNoSelectionExists()
     {
         var baseSettingsService = new InMemoryBaseSettingsService();
         var elyByClient = new FakeElyByAuthClient
         {
-            AuthenticateResult = new ElyByAuthSession("ElyAlpha", "ely-alpha-uuid", "ely-access", "ely-client")
+            ExchangeOAuthCodeResult = new ElyByAuthSession(
+                "ElyAlpha",
+                "ely-alpha-uuid",
+                "ely-access",
+                "ely-client",
+                "ely-refresh",
+                DateTimeOffset.UtcNow.AddHours(1),
+                ElyByAuthFlow.OAuth)
         };
+        var oauthBrowser = new FakeElyByOAuthBrowser { Code = "browser-code" };
 
-        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient);
-        AddMicrosoftAccount(service);
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient, elyByOAuthBrowser: oauthBrowser);
 
-        await service.SignInElyByAccountAsync("ely@example.com", "password", "123456");
+        await service.SignInElyByAccountAsync();
 
         var account = Assert.Single(service.Accounts, account => account.Type == AccountType.ElyBy);
         Assert.Equal("ElyAlpha", account.Name);
@@ -239,13 +265,16 @@ public sealed class AccountServiceTests
         Assert.Equal("elyby:ely-alpha-uuid", account.UniqueId);
         Assert.Equal(AccountProviderIds.ElyBy, account.ProviderId);
         Assert.Same(account, service.GetSelectedAccount());
-        Assert.Equal([("ely@example.com", "password", "123456")], elyByClient.AuthenticateCalls);
+        Assert.Single(oauthBrowser.Requests);
+        Assert.Equal(["browser-code"], elyByClient.ExchangeOAuthCodeCalls);
 
         var storedElyAccounts = baseSettingsService.Peek<List<ElyByStoredAccount>>(SettingsKeys.ElyByAccounts);
         Assert.NotNull(storedElyAccounts);
         var stored = Assert.Single(storedElyAccounts!);
         Assert.Equal("ely-access", stored.AccessToken);
         Assert.Equal("ely-client", stored.ClientToken);
+        Assert.Equal("ely-refresh", stored.RefreshToken);
+        Assert.Equal(ElyByAuthFlow.OAuth, stored.AuthFlow);
     }
 
     [Fact]
@@ -294,6 +323,60 @@ public sealed class AccountServiceTests
         var storedElyAccounts = baseSettingsService.Peek<List<ElyByStoredAccount>>(SettingsKeys.ElyByAccounts);
         Assert.NotNull(storedElyAccounts);
         Assert.Equal("fresh-access", Assert.Single(storedElyAccounts!).AccessToken);
+    }
+
+    [Fact]
+    public async Task AuthenticateAccountAsync_ElyByOAuthRefreshesExpiredAccessToken_AndAddsAuthlibJavaAgent()
+    {
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        baseSettingsService.Set(
+            SettingsKeys.ElyByAccounts,
+            new List<ElyByStoredAccount>
+            {
+                new()
+                {
+                    UniqueId = "elyby:ely-alpha-uuid",
+                    Name = "ElyAlpha",
+                    UUID = "ely-alpha-uuid",
+                    AccessToken = "expired-oauth-access",
+                    ClientToken = "ely-client",
+                    RefreshToken = "ely-refresh",
+                    AuthFlow = ElyByAuthFlow.OAuth,
+                    AccessTokenExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    LastUsed = DateTime.UtcNow.AddHours(-1)
+                }
+            });
+
+        var elyByClient = new FakeElyByAuthClient
+        {
+            RefreshResult = new ElyByAuthSession(
+                "ElyAlpha",
+                "ely-alpha-uuid",
+                "fresh-oauth-access",
+                "ely-client",
+                "ely-refresh",
+                DateTimeOffset.UtcNow.AddHours(1),
+                ElyByAuthFlow.OAuth)
+        };
+        var authlibInjector = new FakeAuthlibInjectorService();
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient, authlibInjectorService: authlibInjector);
+        await service.InitializeAsync("client-id");
+        await service.LoadAllAccountsAsync();
+
+        var account = Assert.Single(service.Accounts, account => account.Type == AccountType.ElyBy);
+        var result = await service.AuthenticateAccountAsync(account);
+
+        Assert.Equal("fresh-oauth-access", result.Session.AccessToken);
+        Assert.Empty(elyByClient.ValidateCalls);
+        Assert.Equal(["elyby:ely-alpha-uuid"], elyByClient.RefreshCalls);
+        Assert.Equal(1, authlibInjector.Calls);
+
+        var storedElyAccounts = baseSettingsService.Peek<List<ElyByStoredAccount>>(SettingsKeys.ElyByAccounts);
+        Assert.NotNull(storedElyAccounts);
+        var stored = Assert.Single(storedElyAccounts!);
+        Assert.Equal("fresh-oauth-access", stored.AccessToken);
+        Assert.Equal("ely-refresh", stored.RefreshToken);
+        Assert.Equal(ElyByAuthFlow.OAuth, stored.AuthFlow);
     }
 
     [Fact]
@@ -413,6 +496,7 @@ public sealed class AccountServiceTests
         FakeMicrosoftAccountClient microsoftAccountClient,
         FakeNotificationService notificationService,
         FakeElyByAuthClient? elyByClient = null,
+        FakeElyByOAuthBrowser? elyByOAuthBrowser = null,
         FakeAuthlibInjectorService? authlibInjectorService = null)
         => new(
             NullLogger<AccountService>.Instance,
@@ -423,17 +507,20 @@ public sealed class AccountServiceTests
             notificationService,
             elyByClient,
             new ElyByAccountStore(baseSettingsService),
+            elyByOAuthBrowser ?? new FakeElyByOAuthBrowser(),
             authlibInjectorService ?? new FakeAuthlibInjectorService());
 
     private static AccountService CreateServiceWithEly(
         InMemoryBaseSettingsService baseSettingsService,
         FakeElyByAuthClient? elyByClient = null,
+        FakeElyByOAuthBrowser? elyByOAuthBrowser = null,
         FakeAuthlibInjectorService? authlibInjectorService = null)
         => CreateService(
             baseSettingsService,
             new FakeMicrosoftAccountClient(),
             new FakeNotificationService(),
             elyByClient,
+            elyByOAuthBrowser,
             authlibInjectorService);
 
     private static void AddMicrosoftAccount(AccountService service, string name = "Microsoft")

--- a/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
+++ b/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
@@ -80,6 +80,34 @@ public sealed class AccountServiceTests
     }
 
     [Fact]
+    public async Task SignInElyByAccountAsync_CanceledDuringBrowserAuthorization_DoesNotAddAccount()
+    {
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        var elyByClient = new FakeElyByAuthClient();
+        var authorizationStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var oauthBrowser = new FakeElyByOAuthBrowser
+        {
+            OnAuthorizeAsync = async (_, cancellationToken) =>
+            {
+                authorizationStarted.SetResult(true);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new ElyByOAuthAuthorizationResult("unused-code");
+            }
+        };
+
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient, elyByOAuthBrowser: oauthBrowser);
+        using var cancellation = new CancellationTokenSource();
+
+        var signInTask = service.SignInElyByAccountAsync(cancellation.Token);
+        await authorizationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => signInTask);
+        Assert.Empty(service.Accounts);
+        Assert.Empty(elyByClient.ExchangeOAuthCodeCalls);
+    }
+
+    [Fact]
     public void SetSelectedAccount_ElyByWithoutMicrosoftAccount_SelectsAccount()
     {
         var service = CreateService(new InMemoryBaseSettingsService());
@@ -159,7 +187,7 @@ public sealed class AccountServiceTests
     public async Task SignInMicrosoftAccountAsync_SelectsMaterializedAccount_WhenNoSelectionExists()
     {
         var microsoftClient = new FakeMicrosoftAccountClient();
-        microsoftClient.OnInteractiveSignInAsync = client =>
+        microsoftClient.OnInteractiveSignInAsync = (client, _) =>
         {
             var identifier = "ms-new";
             client.Accounts.Add(new MicrosoftAccountInfo(identifier, "New Microsoft", identifier, DateTime.UtcNow));
@@ -180,11 +208,37 @@ public sealed class AccountServiceTests
     }
 
     [Fact]
+    public async Task SignInMicrosoftAccountAsync_CanceledDuringInteractiveSignIn_DoesNotMaterializeAccount()
+    {
+        var signInStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var microsoftClient = new FakeMicrosoftAccountClient
+        {
+            OnInteractiveSignInAsync = async (_, cancellationToken) =>
+            {
+                signInStarted.SetResult(true);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new MicrosoftInteractiveSignInResult("unused-id", "Unused", "unused-id");
+            }
+        };
+
+        var service = CreateService(new InMemoryBaseSettingsService(), microsoftClient);
+        await service.InitializeAsync("client-id");
+        using var cancellation = new CancellationTokenSource();
+
+        var signInTask = service.SignInMicrosoftAccountAsync(cancellation.Token);
+        await signInStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => signInTask);
+        Assert.Empty(service.Accounts);
+    }
+
+    [Fact]
     public async Task SignInMicrosoftAccountAsync_Throws_WhenAccountDoesNotMaterialize()
     {
         var microsoftClient = new FakeMicrosoftAccountClient
         {
-            OnInteractiveSignInAsync = _ => Task.FromResult(new MicrosoftInteractiveSignInResult("missing-id", "Ghost", "missing-id"))
+            OnInteractiveSignInAsync = (_, _) => Task.FromResult(new MicrosoftInteractiveSignInResult("missing-id", "Ghost", "missing-id"))
         };
 
         var service = CreateService(new InMemoryBaseSettingsService(), microsoftClient);

--- a/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
+++ b/Emerald.CoreX.Tests/Services/AccountServiceTests.cs
@@ -2,6 +2,9 @@ using System.Linq;
 using Emerald.CoreX.Helpers;
 using Emerald.CoreX.Models;
 using Emerald.CoreX.Services;
+using Emerald.CoreX.Services.Auth;
+using Emerald.CoreX.Services.Auth.ElyBy;
+using Emerald.CoreX.Services.Auth.Microsoft;
 using Emerald.CoreX.Tests.Support;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -17,6 +20,14 @@ public sealed class AccountServiceTests
         var service = CreateService(new InMemoryBaseSettingsService());
 
         Assert.True(service.RequireMicrosoftAccountForOfflineAccounts);
+    }
+
+    [Fact]
+    public void RequireMicrosoftAccountForElyByAccounts_IsEnabled()
+    {
+        var service = CreateService(new InMemoryBaseSettingsService());
+
+        Assert.True(service.RequireMicrosoftAccountForElyByAccounts);
     }
 
     [Fact]
@@ -52,6 +63,42 @@ public sealed class AccountServiceTests
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.AuthenticateAccountAsync(offline));
 
         Assert.Equal("Offline accounts require at least one Microsoft account.", exception.Message);
+    }
+
+    [Fact]
+    public async Task SignInElyByAccountAsync_WithoutMicrosoftAccount_Throws()
+    {
+        var service = CreateServiceWithEly(new InMemoryBaseSettingsService());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SignInElyByAccountAsync("ely@example.com", "password"));
+
+        Assert.Equal("Signing in with Ely.by requires at least one Microsoft account.", exception.Message);
+    }
+
+    [Fact]
+    public void SetSelectedAccount_ElyByWithoutMicrosoftAccount_Throws()
+    {
+        var service = CreateService(new InMemoryBaseSettingsService());
+        var elyBy = new EAccount("ElyAlpha", AccountType.ElyBy, "ely-alpha-uuid", "elyby:ely-alpha-uuid");
+        service.Accounts.Add(elyBy);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.SetSelectedAccount(elyBy));
+
+        Assert.Equal("Selecting an Ely.by account requires at least one Microsoft account.", exception.Message);
+        Assert.Null(service.GetSelectedAccount());
+    }
+
+    [Fact]
+    public async Task AuthenticateAccountAsync_ElyByWithoutMicrosoftAccount_Throws()
+    {
+        var service = CreateService(new InMemoryBaseSettingsService());
+        var elyBy = new EAccount("ElyAlpha", AccountType.ElyBy, "ely-alpha-uuid", "elyby:ely-alpha-uuid");
+        service.Accounts.Add(elyBy);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.AuthenticateAccountAsync(elyBy));
+
+        Assert.Equal("Ely.by accounts require at least one Microsoft account.", exception.Message);
     }
 
     [Fact]
@@ -173,6 +220,83 @@ public sealed class AccountServiceTests
     }
 
     [Fact]
+    public async Task SignInElyByAccountAsync_AddsStoredAccount_AndSelectsWhenNoSelectionExists()
+    {
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        var elyByClient = new FakeElyByAuthClient
+        {
+            AuthenticateResult = new ElyByAuthSession("ElyAlpha", "ely-alpha-uuid", "ely-access", "ely-client")
+        };
+
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient);
+        AddMicrosoftAccount(service);
+
+        await service.SignInElyByAccountAsync("ely@example.com", "password", "123456");
+
+        var account = Assert.Single(service.Accounts, account => account.Type == AccountType.ElyBy);
+        Assert.Equal("ElyAlpha", account.Name);
+        Assert.Equal("ely-alpha-uuid", account.UUID);
+        Assert.Equal("elyby:ely-alpha-uuid", account.UniqueId);
+        Assert.Equal(AccountProviderIds.ElyBy, account.ProviderId);
+        Assert.Same(account, service.GetSelectedAccount());
+        Assert.Equal([("ely@example.com", "password", "123456")], elyByClient.AuthenticateCalls);
+
+        var storedElyAccounts = baseSettingsService.Peek<List<ElyByStoredAccount>>(SettingsKeys.ElyByAccounts);
+        Assert.NotNull(storedElyAccounts);
+        var stored = Assert.Single(storedElyAccounts!);
+        Assert.Equal("ely-access", stored.AccessToken);
+        Assert.Equal("ely-client", stored.ClientToken);
+    }
+
+    [Fact]
+    public async Task AuthenticateAccountAsync_ElyByRefreshesExpiredToken_AndAddsAuthlibJavaAgent()
+    {
+        var baseSettingsService = new InMemoryBaseSettingsService();
+        baseSettingsService.Set(
+            SettingsKeys.ElyByAccounts,
+            new List<ElyByStoredAccount>
+            {
+                new()
+                {
+                    UniqueId = "elyby:ely-alpha-uuid",
+                    Name = "ElyAlpha",
+                    UUID = "ely-alpha-uuid",
+                    AccessToken = "expired-access",
+                    ClientToken = "ely-client",
+                    LastUsed = DateTime.UtcNow.AddHours(-1)
+                }
+            });
+
+        var elyByClient = new FakeElyByAuthClient
+        {
+            ValidateResult = false,
+            RefreshResult = new ElyByAuthSession("ElyAlpha", "ely-alpha-uuid", "fresh-access", "ely-client")
+        };
+        var authlibInjector = new FakeAuthlibInjectorService();
+        var service = CreateServiceWithEly(baseSettingsService, elyByClient: elyByClient, authlibInjectorService: authlibInjector);
+        await service.InitializeAsync("client-id");
+        await service.LoadAllAccountsAsync();
+        AddMicrosoftAccount(service);
+
+        var account = Assert.Single(service.Accounts, account => account.Type == AccountType.ElyBy);
+        var result = await service.AuthenticateAccountAsync(account);
+
+        Assert.Equal("ElyAlpha", result.Session.Username);
+        Assert.Equal("ely-alpha-uuid", result.Session.UUID);
+        Assert.Equal("fresh-access", result.Session.AccessToken);
+        Assert.Equal("ely-client", result.Session.ClientToken);
+        Assert.Equal("msa", result.Session.UserType);
+        Assert.Equal([("expired-access", "ely-client")], elyByClient.ValidateCalls);
+        Assert.Equal(["elyby:ely-alpha-uuid"], elyByClient.RefreshCalls);
+        Assert.Equal(1, authlibInjector.Calls);
+        Assert.Contains(result.RuntimeOptions.ExtraJvmArguments, argument => argument.Values.Contains("-javaagent:/fake/authlib-injector.jar=ely.by"));
+
+        var storedElyAccounts = baseSettingsService.Peek<List<ElyByStoredAccount>>(SettingsKeys.ElyByAccounts);
+        Assert.NotNull(storedElyAccounts);
+        Assert.Equal("fresh-access", Assert.Single(storedElyAccounts!).AccessToken);
+    }
+
+    [Fact]
     public async Task RemoveAccountAsync_MicrosoftUsesIdentifier_AndReloadsFromBackend()
     {
         var baseSettingsService = new InMemoryBaseSettingsService();
@@ -287,14 +411,30 @@ public sealed class AccountServiceTests
     private static AccountService CreateService(
         InMemoryBaseSettingsService baseSettingsService,
         FakeMicrosoftAccountClient microsoftAccountClient,
-        FakeNotificationService notificationService)
+        FakeNotificationService notificationService,
+        FakeElyByAuthClient? elyByClient = null,
+        FakeAuthlibInjectorService? authlibInjectorService = null)
         => new(
             NullLogger<AccountService>.Instance,
             baseSettingsService,
             new ImmediateUiDispatcher(),
             "/tmp/emerald-tests/cml_accounts.json",
             microsoftAccountClient,
-            notificationService);
+            notificationService,
+            elyByClient,
+            new ElyByAccountStore(baseSettingsService),
+            authlibInjectorService ?? new FakeAuthlibInjectorService());
+
+    private static AccountService CreateServiceWithEly(
+        InMemoryBaseSettingsService baseSettingsService,
+        FakeElyByAuthClient? elyByClient = null,
+        FakeAuthlibInjectorService? authlibInjectorService = null)
+        => CreateService(
+            baseSettingsService,
+            new FakeMicrosoftAccountClient(),
+            new FakeNotificationService(),
+            elyByClient,
+            authlibInjectorService);
 
     private static void AddMicrosoftAccount(AccountService service, string name = "Microsoft")
     {

--- a/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
+++ b/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
@@ -131,13 +131,38 @@ internal sealed class FakeMicrosoftAccountClient : IMicrosoftAccountClient
 internal sealed class FakeElyByAuthClient : IElyByAuthClient
 {
     public ElyByAuthSession AuthenticateResult { get; set; } = new("ElyPlayer", "ely-uuid", "ely-access", "ely-client");
+    public ElyByAuthSession ExchangeOAuthCodeResult { get; set; } = new(
+        "ElyOAuthPlayer",
+        "ely-oauth-uuid",
+        "ely-oauth-access",
+        "ely-oauth-client",
+        "ely-oauth-refresh",
+        DateTimeOffset.UtcNow.AddHours(1),
+        ElyByAuthFlow.OAuth);
     public ElyByAuthSession RefreshResult { get; set; } = new("ElyPlayer", "ely-uuid", "ely-refreshed", "ely-client");
     public bool ValidateResult { get; set; } = true;
 
+    public List<(string State, string? LoginHint)> AuthorizationRequestCalls { get; } = [];
+    public List<string> ExchangeOAuthCodeCalls { get; } = [];
     public List<(string Login, string Password, string? TwoFactorCode)> AuthenticateCalls { get; } = [];
     public List<(string AccessToken, string ClientToken)> ValidateCalls { get; } = [];
     public List<string> RefreshCalls { get; } = [];
     public List<string> InvalidateCalls { get; } = [];
+
+    public ElyByOAuthAuthorizationRequest CreateOAuthAuthorizationRequest(string state, string? loginHint = null)
+    {
+        AuthorizationRequestCalls.Add((state, loginHint));
+        return new ElyByOAuthAuthorizationRequest(
+            new Uri($"https://account.ely.by/oauth2/v1?state={state}"),
+            new Uri("http://127.0.0.1:58135/oauth/elyby/"),
+            state);
+    }
+
+    public Task<ElyByAuthSession> ExchangeOAuthCodeAsync(string code, CancellationToken cancellationToken = default)
+    {
+        ExchangeOAuthCodeCalls.Add(code);
+        return Task.FromResult(ExchangeOAuthCodeResult);
+    }
 
     public Task<ElyByAuthSession> AuthenticateAsync(
         string login,
@@ -165,6 +190,20 @@ internal sealed class FakeElyByAuthClient : IElyByAuthClient
     {
         InvalidateCalls.Add(account.UniqueId);
         return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeElyByOAuthBrowser : IElyByOAuthBrowser
+{
+    public string Code { get; set; } = "ely-oauth-code";
+    public List<ElyByOAuthAuthorizationRequest> Requests { get; } = [];
+
+    public Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Requests.Add(request);
+        return Task.FromResult(new ElyByOAuthAuthorizationResult(Code));
     }
 }
 

--- a/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
+++ b/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
@@ -78,7 +78,7 @@ internal sealed class FakeMicrosoftAccountClient : IMicrosoftAccountClient
     public string? InitializedAccountStorePath { get; private set; }
     public string? DefaultAccountIdentifier { get; set; }
 
-    public Func<FakeMicrosoftAccountClient, Task<MicrosoftInteractiveSignInResult>>? OnInteractiveSignInAsync { get; set; }
+    public Func<FakeMicrosoftAccountClient, CancellationToken, Task<MicrosoftInteractiveSignInResult>>? OnInteractiveSignInAsync { get; set; }
     public Func<string, MSession>? AuthenticateFactory { get; set; }
 
     public Task InitializeAsync(string clientId, string accountStorePath)
@@ -94,14 +94,15 @@ internal sealed class FakeMicrosoftAccountClient : IMicrosoftAccountClient
     public string? GetDefaultAccountIdentifier()
         => DefaultAccountIdentifier;
 
-    public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync()
+    public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (OnInteractiveSignInAsync is null)
         {
             return new MicrosoftInteractiveSignInResult(DefaultAccountIdentifier, null, null);
         }
 
-        return await OnInteractiveSignInAsync(this);
+        return await OnInteractiveSignInAsync(this, cancellationToken);
     }
 
     public Task<MSession> AuthenticateAsync(string accountIdentifier)
@@ -160,6 +161,7 @@ internal sealed class FakeElyByAuthClient : IElyByAuthClient
 
     public Task<ElyByAuthSession> ExchangeOAuthCodeAsync(string code, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         ExchangeOAuthCodeCalls.Add(code);
         return Task.FromResult(ExchangeOAuthCodeResult);
     }
@@ -170,24 +172,28 @@ internal sealed class FakeElyByAuthClient : IElyByAuthClient
         string? twoFactorCode = null,
         CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         AuthenticateCalls.Add((login, password, twoFactorCode));
         return Task.FromResult(AuthenticateResult);
     }
 
     public Task<bool> ValidateAsync(string accessToken, string clientToken, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         ValidateCalls.Add((accessToken, clientToken));
         return Task.FromResult(ValidateResult);
     }
 
     public Task<ElyByAuthSession> RefreshAsync(ElyByStoredAccount account, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         RefreshCalls.Add(account.UniqueId);
         return Task.FromResult(RefreshResult);
     }
 
     public Task InvalidateAsync(ElyByStoredAccount account, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         InvalidateCalls.Add(account.UniqueId);
         return Task.CompletedTask;
     }
@@ -197,13 +203,18 @@ internal sealed class FakeElyByOAuthBrowser : IElyByOAuthBrowser
 {
     public string Code { get; set; } = "ely-oauth-code";
     public List<ElyByOAuthAuthorizationRequest> Requests { get; } = [];
+    public Func<ElyByOAuthAuthorizationRequest, CancellationToken, Task<ElyByOAuthAuthorizationResult>>? OnAuthorizeAsync { get; set; }
 
     public Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
         ElyByOAuthAuthorizationRequest request,
         CancellationToken cancellationToken = default)
     {
         Requests.Add(request);
-        return Task.FromResult(new ElyByOAuthAuthorizationResult(Code));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return OnAuthorizeAsync is not null
+            ? OnAuthorizeAsync(request, cancellationToken)
+            : Task.FromResult(new ElyByOAuthAuthorizationResult(Code));
     }
 }
 

--- a/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
+++ b/Emerald.CoreX.Tests/Support/TestInfrastructure.cs
@@ -4,6 +4,9 @@ using CmlLib.Core.Auth;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Emerald.CoreX.Notifications;
 using Emerald.CoreX.Services;
+using Emerald.CoreX.Services.Auth.Authlib;
+using Emerald.CoreX.Services.Auth.ElyBy;
+using Emerald.CoreX.Services.Auth.Microsoft;
 using Emerald.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -122,6 +125,58 @@ internal sealed class FakeMicrosoftAccountClient : IMicrosoftAccountClient
         }
 
         return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeElyByAuthClient : IElyByAuthClient
+{
+    public ElyByAuthSession AuthenticateResult { get; set; } = new("ElyPlayer", "ely-uuid", "ely-access", "ely-client");
+    public ElyByAuthSession RefreshResult { get; set; } = new("ElyPlayer", "ely-uuid", "ely-refreshed", "ely-client");
+    public bool ValidateResult { get; set; } = true;
+
+    public List<(string Login, string Password, string? TwoFactorCode)> AuthenticateCalls { get; } = [];
+    public List<(string AccessToken, string ClientToken)> ValidateCalls { get; } = [];
+    public List<string> RefreshCalls { get; } = [];
+    public List<string> InvalidateCalls { get; } = [];
+
+    public Task<ElyByAuthSession> AuthenticateAsync(
+        string login,
+        string password,
+        string? twoFactorCode = null,
+        CancellationToken cancellationToken = default)
+    {
+        AuthenticateCalls.Add((login, password, twoFactorCode));
+        return Task.FromResult(AuthenticateResult);
+    }
+
+    public Task<bool> ValidateAsync(string accessToken, string clientToken, CancellationToken cancellationToken = default)
+    {
+        ValidateCalls.Add((accessToken, clientToken));
+        return Task.FromResult(ValidateResult);
+    }
+
+    public Task<ElyByAuthSession> RefreshAsync(ElyByStoredAccount account, CancellationToken cancellationToken = default)
+    {
+        RefreshCalls.Add(account.UniqueId);
+        return Task.FromResult(RefreshResult);
+    }
+
+    public Task InvalidateAsync(ElyByStoredAccount account, CancellationToken cancellationToken = default)
+    {
+        InvalidateCalls.Add(account.UniqueId);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeAuthlibInjectorService : IAuthlibInjectorService
+{
+    public string JavaAgentArgument { get; set; } = "-javaagent:/fake/authlib-injector.jar=ely.by";
+    public int Calls { get; private set; }
+
+    public Task<string> GetJavaAgentArgumentAsync(CancellationToken cancellationToken = default)
+    {
+        Calls++;
+        return Task.FromResult(JavaAgentArgument);
     }
 }
 

--- a/Emerald.CoreX/Game.cs
+++ b/Emerald.CoreX/Game.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Emerald.CoreX.Runtime;
 using Emerald.CoreX.Services;
+using Emerald.CoreX.Services.Auth;
 using Microsoft.Extensions.Logging;
 
 namespace Emerald.CoreX;
@@ -252,11 +253,21 @@ public partial class Game : ObservableObject
         }
     }
 
-    public async Task<Process> BuildProcess(string version, CmlLib.Core.Auth.MSession session)
+    public async Task<Process> BuildProcess(
+        string version,
+        CmlLib.Core.Auth.MSession session,
+        AccountRuntimeAuthOptions? runtimeAuthOptions = null)
     {
         _logger.LogInformation("Building process for version: {Version}", version);
         var launchOpt = EffectiveSettings.ToMLaunchOption();
         launchOpt.Session = session;
+
+        if (runtimeAuthOptions?.ExtraJvmArguments.Count > 0)
+        {
+            launchOpt.ExtraJvmArguments = launchOpt.ExtraJvmArguments
+                .Concat(runtimeAuthOptions.ExtraJvmArguments)
+                .ToArray();
+        }
 
         if (EffectiveSettings.UseCustomJava)
         {

--- a/Emerald.CoreX/Helpers/BaseSettingsService.cs
+++ b/Emerald.CoreX/Helpers/BaseSettingsService.cs
@@ -15,12 +15,12 @@ public class BaseSettingsService : IBaseSettingsService
 
     private readonly string _settingsFolder;
 
-    public BaseSettingsService(ILogger<BaseSettingsService> logger)
+    public BaseSettingsService(ILogger<BaseSettingsService> logger, string? settingsFolderPath = null)
     {
         _logger = logger;
 
         // Use the LocalFolder path as the base folder for file-based settings
-        _settingsFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Emerald", "Settings");
+        _settingsFolder =  settingsFolderPath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Emerald", "Settings");
 
         // Ensure the directory exists immediately
         if (!Directory.Exists(_settingsFolder))

--- a/Emerald.CoreX/Helpers/SettingsKeys.cs
+++ b/Emerald.CoreX/Helpers/SettingsKeys.cs
@@ -13,5 +13,6 @@ public static class SettingsKeys
     public const string Settings = "Settings";
     public const string MinecraftAccounts = "MinecraftAccounts";
     public const string SelectedMinecraftAccount = "SelectedMinecraftAccount";
+    public const string ElyByAccounts = "ElyByAccounts";
     public const string StoreInstalledItems = "StoreInstalledItems";
 }

--- a/Emerald.CoreX/Models/EAccount.cs
+++ b/Emerald.CoreX/Models/EAccount.cs
@@ -7,13 +7,15 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Emerald.CoreX.Services.Auth;
 
 namespace Emerald.CoreX.Models;
 
 public enum AccountType
 {
     Offline,
-    Microsoft
+    Microsoft,
+    ElyBy
 }
 
 [ObservableObject]
@@ -23,6 +25,7 @@ public partial class EAccount
 
     private string _name = string.Empty;
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ProviderDisplayName))]
     private AccountType _type;
 
     [ObservableProperty]
@@ -34,9 +37,20 @@ public partial class EAccount
     [ObservableProperty]
     private string _uniqueId = string.Empty;
 
+    [ObservableProperty]
+    private string _providerId = string.Empty;
+
     [JsonIgnore]
     [ObservableProperty]
     private bool _isSelected;
+
+    [JsonIgnore]
+    public string ProviderDisplayName => Type switch
+    {
+        AccountType.Microsoft => "Microsoft",
+        AccountType.ElyBy => "Ely.by",
+        _ => "Offline"
+    };
 
     public EAccount() { }
 
@@ -48,6 +62,7 @@ public partial class EAccount
         UniqueId = string.IsNullOrWhiteSpace(uniqueId)
             ? Guid.NewGuid().ToString()
             : uniqueId;
+        ProviderId = AccountProviderIds.FromAccountType(type);
         LastUsed = DateTime.UtcNow;
     }
 }

--- a/Emerald.CoreX/Runtime/GameRuntimeService.cs
+++ b/Emerald.CoreX/Runtime/GameRuntimeService.cs
@@ -204,10 +204,13 @@ public sealed class GameRuntimeService : IGameRuntimeService
         try
         {
             _logger.LogDebug("Authenticating launch account for {GameName}.", game.Version.DisplayName);
-            var mcSession = await _accountService.AuthenticateAccountAsync(account);
+            var authenticationResult = await _accountService.AuthenticateAccountAsync(account);
             ThrowIfLaunchCancelled(runtime);
 
-            var process = await game.BuildProcess(game.Version.RealVersion, mcSession);
+            var process = await game.BuildProcess(
+                game.Version.RealVersion,
+                authenticationResult.Session,
+                authenticationResult.RuntimeOptions);
             runtime.Process = process;
 
             _logger.LogDebug(

--- a/Emerald.CoreX/Services/AccountService.Authentication.cs
+++ b/Emerald.CoreX/Services/AccountService.Authentication.cs
@@ -1,0 +1,98 @@
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services;
+
+public sealed partial class AccountService
+{
+    public async Task RemoveAccountAsync(EAccount account)
+    {
+        _logger.LogInformation("Removing account '{Name}' ({Type}).", account.Name, account.Type);
+
+        if (account.Type == AccountType.Microsoft)
+        {
+            await EnsureInitializedAsync().ConfigureAwait(false);
+            await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
+            _logger.LogInformation("Signed out Microsoft account '{Name}' ({Identifier}).", account.Name, account.UniqueId);
+            await LoadAllAccountsAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (account.Type == AccountType.ElyBy)
+        {
+            await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
+            _logger.LogInformation("Signed out Ely.by account '{Name}' ({Identifier}).", account.Name, account.UniqueId);
+        }
+
+        var wasSelected = false;
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await _uiDispatcher.InvokeAsync(() =>
+            {
+                wasSelected = string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal);
+                _accounts.Remove(account);
+
+                if (wasSelected)
+                    ApplySelectedAccountCore(null, persist: false);
+
+                EnforceAccountSelectionPoliciesCore(persist: false);
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        PersistAccounts();
+    }
+
+    public async Task<GameAuthenticationResult> AuthenticateAccountAsync(EAccount account)
+    {
+        _logger.LogInformation("Authenticating '{Name}' ({Type}).", account.Name, account.Type);
+
+        if (account.Type == AccountType.Offline)
+        {
+            EnsureOfflineAccountPolicyMet("Offline accounts require at least one Microsoft account.");
+        }
+        else if (account.Type == AccountType.ElyBy)
+        {
+            EnsureElyByAccountPolicyMet("Ely.by accounts require at least one Microsoft account.");
+        }
+        else if (account.Type == AccountType.Microsoft)
+        {
+            await EnsureInitializedAsync().ConfigureAwait(false);
+        }
+
+        var authenticationResult = await GetAuthenticationProvider(account.Type)
+            .AuthenticateAsync(account)
+            .ConfigureAwait(false);
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await _uiDispatcher.InvokeAsync(() =>
+            {
+                var matched = _accounts.FirstOrDefault(candidate =>
+                    ReferenceEquals(candidate, account) ||
+                    string.Equals(candidate.UniqueId, account.UniqueId, StringComparison.Ordinal));
+
+                if (matched is not null)
+                    matched.LastUsed = DateTime.UtcNow;
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        PersistAccounts();
+        return authenticationResult;
+    }
+
+    private IAccountAuthenticationProvider GetAuthenticationProvider(AccountType accountType)
+        => _authenticationProviders.TryGetValue(accountType, out var provider)
+            ? provider
+            : throw new ArgumentException($"Unknown account type: {accountType}");
+}

--- a/Emerald.CoreX/Services/AccountService.Loading.cs
+++ b/Emerald.CoreX/Services/AccountService.Loading.cs
@@ -158,6 +158,9 @@ public sealed partial class AccountService
             UUID = session.UUID,
             AccessToken = session.AccessToken,
             ClientToken = session.ClientToken,
+            RefreshToken = session.RefreshToken ?? string.Empty,
+            AccessTokenExpiresAt = session.AccessTokenExpiresAt,
+            AuthFlow = session.AuthFlow,
             LastUsed = DateTime.UtcNow
         };
 

--- a/Emerald.CoreX/Services/AccountService.Loading.cs
+++ b/Emerald.CoreX/Services/AccountService.Loading.cs
@@ -1,0 +1,180 @@
+using Emerald.CoreX.Helpers;
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+using Emerald.CoreX.Services.Auth.ElyBy;
+using Emerald.CoreX.Services.Auth.Microsoft;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services;
+
+public sealed partial class AccountService
+{
+    public async Task LoadAllAccountsAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+        await _loadGate.WaitAsync().ConfigureAwait(false);
+
+        try
+        {
+            _logger.LogInformation("Loading accounts from Emerald settings, the CmlLib account store, and Ely.by account store.");
+            var loadState = BuildAccountLoadState();
+
+            _logger.LogInformation(
+                "Found {OfflineCount} offline accounts, {StoredMicrosoftCount} stored Microsoft accounts, {ElyByCount} Ely.by accounts, and {OnlineCount} Microsoft accounts in CmlLib.",
+                loadState.OfflineCount,
+                loadState.StoredMicrosoftCount,
+                loadState.ElyByCount,
+                loadState.MicrosoftCount);
+
+            await _gate.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await _uiDispatcher.InvokeAsync(() =>
+                {
+                    ApplyLoadedAccountsCore(loadState.Accounts);
+                }).ConfigureAwait(false);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+
+            PersistAccounts();
+            NotifyLoggedOutMicrosoftAccounts(loadState.LoggedOutMicrosoftAccountNames);
+            _logger.LogInformation(
+                "Loaded {TotalCount} accounts ({OfflineCount} offline, {MicrosoftCount} Microsoft, {ElyByCount} Ely.by). Logged out Microsoft accounts detected: {LoggedOutMicrosoftCount}.",
+                loadState.TotalCount,
+                loadState.OfflineCount,
+                loadState.MicrosoftCount,
+                loadState.ElyByCount,
+                loadState.LoggedOutMicrosoftCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load accounts.");
+            throw;
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    private AccountLoadState BuildAccountLoadState()
+    {
+        var storedAccounts = _settingsService.Get(SettingsKeys.MinecraftAccounts, new List<EAccount>());
+        var offlineAccounts = storedAccounts
+            .Where(account => account.Type == AccountType.Offline)
+            .Select(CloneStoredAccount)
+            .ToList();
+        var storedMicrosoftAccounts = storedAccounts
+            .Where(account => account.Type == AccountType.Microsoft)
+            .Select(CloneStoredAccount)
+            .ToList();
+        var storedElyByAccounts = _elyByAccountStore.GetAccounts()
+            .Select(CreateElyByAccount)
+            .ToList();
+        var onlineMicrosoftAccounts = _microsoftAccountClient.GetAccounts()
+            .Where(account =>
+            {
+                if (!string.IsNullOrWhiteSpace(account.Identifier))
+                    return true;
+
+                _logger.LogWarning("Skipping a Microsoft account with a missing identifier.");
+                return false;
+            })
+            .Select(CreateMicrosoftAccount)
+            .ToList();
+
+        var onlineIdentifiers = new HashSet<string>(
+            onlineMicrosoftAccounts.Select(account => account.UniqueId),
+            StringComparer.Ordinal);
+        var loggedOutAccountNames = storedMicrosoftAccounts
+            .Where(account => !onlineIdentifiers.Contains(account.UniqueId))
+            .Select(account => account.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var loadedAccounts = new List<EAccount>(offlineAccounts.Count + onlineMicrosoftAccounts.Count + storedElyByAccounts.Count);
+        loadedAccounts.AddRange(offlineAccounts);
+        loadedAccounts.AddRange(onlineMicrosoftAccounts);
+        loadedAccounts.AddRange(storedElyByAccounts);
+
+        return new AccountLoadState(
+            loadedAccounts,
+            offlineAccounts.Count,
+            storedMicrosoftAccounts.Count,
+            onlineMicrosoftAccounts.Count,
+            storedElyByAccounts.Count,
+            loggedOutAccountNames);
+    }
+
+    private void NotifyLoggedOutMicrosoftAccounts(IReadOnlyList<string> loggedOutMicrosoftAccountNames)
+    {
+        if (_notificationService is null || loggedOutMicrosoftAccountNames.Count == 0)
+            return;
+
+        if (loggedOutMicrosoftAccountNames.Count == 1)
+        {
+            _notificationService.Warning(
+                "Microsoft account signed out",
+                $"'{loggedOutMicrosoftAccountNames[0]}' is no longer signed in and was removed from Accounts.");
+            return;
+        }
+
+        _notificationService.Warning(
+            "Microsoft accounts signed out",
+            $"{loggedOutMicrosoftAccountNames.Count} Microsoft accounts are no longer signed in and were removed from Accounts.");
+    }
+
+    private static EAccount CreateMicrosoftAccount(MicrosoftAccountInfo account)
+        => new(
+            account.Name,
+            AccountType.Microsoft,
+            string.IsNullOrWhiteSpace(account.UUID) ? account.Identifier : account.UUID,
+            account.Identifier)
+        {
+            LastUsed = account.LastAccess == default ? DateTime.UtcNow : account.LastAccess,
+            ProviderId = AccountProviderIds.Microsoft
+        };
+
+    private static EAccount CreateElyByAccount(ElyByStoredAccount account)
+        => new(
+            account.Name,
+            AccountType.ElyBy,
+            account.UUID,
+            account.UniqueId)
+        {
+            LastUsed = account.LastUsed == default ? DateTime.UtcNow : account.LastUsed,
+            ProviderId = AccountProviderIds.ElyBy
+        };
+
+    private static ElyByStoredAccount CreateStoredElyByAccount(ElyByAuthSession session)
+        => new()
+        {
+            UniqueId = CreateElyByUniqueId(session.UUID),
+            Name = session.Name,
+            UUID = session.UUID,
+            AccessToken = session.AccessToken,
+            ClientToken = session.ClientToken,
+            LastUsed = DateTime.UtcNow
+        };
+
+    private static string CreateElyByUniqueId(string uuid)
+        => $"{AccountProviderIds.ElyBy}:{uuid}";
+
+    private void ApplyLoadedAccountsCore(IEnumerable<EAccount> accounts)
+    {
+        _accounts.Clear();
+
+        foreach (var account in accounts)
+        {
+            EnsureProviderId(account);
+            _accounts.Add(account);
+        }
+
+        RestoreSelectedAccountCore();
+        EnforceAccountSelectionPoliciesCore(persist: false);
+    }
+}

--- a/Emerald.CoreX/Services/AccountService.Persistence.cs
+++ b/Emerald.CoreX/Services/AccountService.Persistence.cs
@@ -1,0 +1,74 @@
+using Emerald.CoreX.Helpers;
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services;
+
+public sealed partial class AccountService
+{
+    private void PersistAccounts()
+    {
+        try
+        {
+            List<EAccount> storedAccounts = [];
+            string? selectedAccountId = null;
+            _uiDispatcher.Invoke(() =>
+            {
+                storedAccounts = _accounts
+                    .Select(CloneStoredAccount)
+                    .ToList();
+                selectedAccountId = _selectedAccountId;
+            });
+
+            _settingsService.Set(SettingsKeys.MinecraftAccounts, storedAccounts);
+            _settingsService.Set(SettingsKeys.SelectedMinecraftAccount, selectedAccountId);
+            var offlineCount = storedAccounts.Count(account => account.Type == AccountType.Offline);
+            var microsoftCount = storedAccounts.Count(account => account.Type == AccountType.Microsoft);
+            var elyByCount = storedAccounts.Count(account => account.Type == AccountType.ElyBy);
+            _logger.LogDebug(
+                "Persisted {TotalCount} accounts ({OfflineCount} offline, {MicrosoftCount} Microsoft, {ElyByCount} Ely.by). SelectedAccountId: {SelectedAccountId}.",
+                storedAccounts.Count,
+                offlineCount,
+                microsoftCount,
+                elyByCount,
+                selectedAccountId ?? "None");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist accounts.");
+            throw;
+        }
+    }
+
+    private EAccount EnsureUniqueId(EAccount account)
+    {
+        if (string.IsNullOrWhiteSpace(account.UniqueId))
+        {
+            account.UniqueId = Guid.NewGuid().ToString();
+            _logger.LogInformation(
+                "Generated missing UniqueId for account '{Name}' ({Type}).",
+                account.Name,
+                account.Type);
+        }
+
+        return account;
+    }
+
+    private static void EnsureProviderId(EAccount account)
+    {
+        if (string.IsNullOrWhiteSpace(account.ProviderId))
+            account.ProviderId = AccountProviderIds.FromAccountType(account.Type);
+    }
+
+    private EAccount CloneStoredAccount(EAccount account)
+    {
+        var storedAccount = EnsureUniqueId(account);
+        EnsureProviderId(storedAccount);
+        return new EAccount(storedAccount.Name, storedAccount.Type, storedAccount.UUID, storedAccount.UniqueId)
+        {
+            LastUsed = storedAccount.LastUsed,
+            ProviderId = storedAccount.ProviderId
+        };
+    }
+}

--- a/Emerald.CoreX/Services/AccountService.Selection.cs
+++ b/Emerald.CoreX/Services/AccountService.Selection.cs
@@ -1,0 +1,142 @@
+using Emerald.CoreX.Helpers;
+using Emerald.CoreX.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services;
+
+public sealed partial class AccountService
+{
+    public EAccount? GetMostRecentlyUsedAccount()
+    {
+        EAccount? account = null;
+        _uiDispatcher.Invoke(() =>
+        {
+            account = _accounts.Count == 0
+                ? null
+                : _accounts.OrderByDescending(candidate => candidate.LastUsed).First();
+        });
+
+        return account;
+    }
+
+    public EAccount? GetSelectedAccount()
+    {
+        EAccount? account = null;
+        _uiDispatcher.Invoke(() => account = GetSelectedAccountCore());
+        return account;
+    }
+
+    public void SetSelectedAccount(EAccount? account)
+    {
+        _gate.Wait();
+        try
+        {
+            _uiDispatcher.Invoke(() =>
+            {
+                if (account is null)
+                {
+                    ApplySelectedAccountCore(null, persist: true);
+                    return;
+                }
+
+                var matched = _accounts.FirstOrDefault(candidate =>
+                    ReferenceEquals(candidate, account) ||
+                    string.Equals(candidate.UniqueId, account.UniqueId, StringComparison.Ordinal));
+
+                if (matched is null)
+                {
+                    _logger.LogWarning(
+                        "SetSelectedAccount: account '{Name}' (id={Id}) not found in the collection.",
+                        account.Name,
+                        account.UniqueId);
+                    return;
+                }
+
+                matched = EnsureUniqueId(matched);
+                EnsureProviderId(matched);
+
+                if (matched.Type == AccountType.Offline)
+                    EnsureOfflineAccountPolicyMet("Selecting an offline account requires at least one Microsoft account.");
+
+                if (matched.Type == AccountType.ElyBy)
+                    EnsureElyByAccountPolicyMet("Selecting an Ely.by account requires at least one Microsoft account.");
+
+                ApplySelectedAccountCore(matched.UniqueId, persist: true);
+            });
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private void RestoreSelectedAccountCore()
+    {
+        _selectedAccountId = _settingsService.Get<string?>(SettingsKeys.SelectedMinecraftAccount, null);
+
+        if (!string.IsNullOrWhiteSpace(_selectedAccountId) && GetSelectedAccountCore() is null)
+        {
+            _logger.LogInformation("Previously selected account no longer exists; clearing selection.");
+            ApplySelectedAccountCore(null, persist: false);
+            return;
+        }
+
+        ApplySelectedAccountCore(_selectedAccountId, persist: false);
+    }
+
+    private EAccount? GetSelectedAccountCore()
+        => string.IsNullOrWhiteSpace(_selectedAccountId)
+            ? null
+            : _accounts.FirstOrDefault(account =>
+                string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal));
+
+    private void ApplySelectedAccountCore(string? uniqueId, bool persist)
+    {
+        _selectedAccountId = string.IsNullOrWhiteSpace(uniqueId) ? null : uniqueId;
+
+        foreach (var account in _accounts)
+            account.IsSelected = string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal);
+
+        if (persist)
+            _settingsService.Set(SettingsKeys.SelectedMinecraftAccount, _selectedAccountId);
+    }
+
+    private bool HasMicrosoftAccountCore()
+        => _accounts.Any(account => account.Type == AccountType.Microsoft);
+
+    private bool IsOfflineAccountAllowed()
+        => !RequireMicrosoftAccountForOfflineAccounts || HasMicrosoftAccountCore();
+
+    private bool IsElyByAccountAllowed()
+        => !RequireMicrosoftAccountForElyByAccounts || HasMicrosoftAccountCore();
+
+    private void EnsureOfflineAccountPolicyMet(string message)
+    {
+        if (!IsOfflineAccountAllowed())
+            throw new InvalidOperationException(message);
+    }
+
+    private void EnsureElyByAccountPolicyMet(string message)
+    {
+        if (!IsElyByAccountAllowed())
+            throw new InvalidOperationException(message);
+    }
+
+    private void EnforceAccountSelectionPoliciesCore(bool persist)
+    {
+        var selectedAccount = GetSelectedAccountCore();
+
+        if (selectedAccount?.Type == AccountType.Offline && !IsOfflineAccountAllowed())
+        {
+            _logger.LogInformation("Clearing offline account selection due to policy.");
+            ApplySelectedAccountCore(null, persist);
+            return;
+        }
+
+        if (selectedAccount?.Type == AccountType.ElyBy && !IsElyByAccountAllowed())
+        {
+            _logger.LogInformation("Clearing Ely.by account selection due to policy.");
+            ApplySelectedAccountCore(null, persist);
+        }
+    }
+}

--- a/Emerald.CoreX/Services/AccountService.SignIn.cs
+++ b/Emerald.CoreX/Services/AccountService.SignIn.cs
@@ -1,6 +1,8 @@
 using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth.ElyBy;
 using Emerald.CoreX.Services.Auth.Microsoft;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
 
 namespace Emerald.CoreX.Services;
 
@@ -91,6 +93,25 @@ public sealed partial class AccountService
             materializedAccount.UniqueId);
     }
 
+    public async Task SignInElyByAccountAsync()
+    {
+        EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
+
+        var state = CreateOAuthState();
+        var authorizationRequest = _elyByAuthClient.CreateOAuthAuthorizationRequest(state);
+
+        _logger.LogInformation("Starting Ely.by browser sign-in.");
+        var authorizationResult = await _elyByOAuthBrowser
+            .AuthorizeAsync(authorizationRequest)
+            .ConfigureAwait(false);
+        var session = await _elyByAuthClient
+            .ExchangeOAuthCodeAsync(authorizationResult.Code)
+            .ConfigureAwait(false);
+
+        await AddOrUpdateElyBySessionAsync(session).ConfigureAwait(false);
+        _logger.LogInformation("Ely.by account '{Name}' signed in through OAuth.", session.Name);
+    }
+
     public async Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null)
     {
         if (string.IsNullOrWhiteSpace(login))
@@ -106,6 +127,12 @@ public sealed partial class AccountService
             .AuthenticateAsync(login.Trim(), password, string.IsNullOrWhiteSpace(twoFactorCode) ? null : twoFactorCode.Trim())
             .ConfigureAwait(false);
 
+        await AddOrUpdateElyBySessionAsync(session).ConfigureAwait(false);
+        _logger.LogInformation("Ely.by account '{Name}' signed in.", session.Name);
+    }
+
+    private async Task AddOrUpdateElyBySessionAsync(ElyByAuthSession session)
+    {
         var storedAccount = CreateStoredElyByAccount(session);
         _elyByAccountStore.Upsert(storedAccount);
 
@@ -141,7 +168,13 @@ public sealed partial class AccountService
         }
 
         PersistAccounts();
-        _logger.LogInformation("Ely.by account '{Name}' signed in.", storedAccount.Name);
+    }
+
+    private static string CreateOAuthState()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private static IReadOnlyList<string> BuildMaterializationCandidates(

--- a/Emerald.CoreX/Services/AccountService.SignIn.cs
+++ b/Emerald.CoreX/Services/AccountService.SignIn.cs
@@ -39,9 +39,10 @@ public sealed partial class AccountService
         _logger.LogInformation("Created offline account '{Username}'.", username);
     }
 
-    public async Task SignInMicrosoftAccountAsync()
+    public async Task SignInMicrosoftAccountAsync(CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await EnsureInitializedAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
 
         _logger.LogInformation("Starting interactive Microsoft sign-in.");
         var beforeIdentifiers = _microsoftAccountClient
@@ -50,7 +51,8 @@ public sealed partial class AccountService
             .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
             .ToHashSet(StringComparer.Ordinal);
 
-        var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync().ConfigureAwait(false);
+        var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         _logger.LogInformation(
             "Interactive Microsoft sign-in completed for '{Username}' (candidate identifier: {Identifier}).",
             signInResult.Username ?? "Unknown",
@@ -58,6 +60,7 @@ public sealed partial class AccountService
 
         var afterAccounts = _microsoftAccountClient.GetAccounts();
         await LoadAllAccountsAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var candidateIdentifiers = BuildMaterializationCandidates(
             signInResult,
@@ -66,7 +69,7 @@ public sealed partial class AccountService
             _microsoftAccountClient.GetDefaultAccountIdentifier());
 
         EAccount? materializedAccount = null;
-        await _gate.WaitAsync().ConfigureAwait(false);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             await _uiDispatcher.InvokeAsync(() =>
@@ -93,26 +96,31 @@ public sealed partial class AccountService
             materializedAccount.UniqueId);
     }
 
-    public async Task SignInElyByAccountAsync()
+    public async Task SignInElyByAccountAsync(CancellationToken cancellationToken = default)
     {
         EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
+        cancellationToken.ThrowIfCancellationRequested();
 
         var state = CreateOAuthState();
         var authorizationRequest = _elyByAuthClient.CreateOAuthAuthorizationRequest(state);
 
         _logger.LogInformation("Starting Ely.by browser sign-in.");
         var authorizationResult = await _elyByOAuthBrowser
-            .AuthorizeAsync(authorizationRequest)
+            .AuthorizeAsync(authorizationRequest, cancellationToken)
             .ConfigureAwait(false);
         var session = await _elyByAuthClient
-            .ExchangeOAuthCodeAsync(authorizationResult.Code)
+            .ExchangeOAuthCodeAsync(authorizationResult.Code, cancellationToken)
             .ConfigureAwait(false);
 
-        await AddOrUpdateElyBySessionAsync(session).ConfigureAwait(false);
+        await AddOrUpdateElyBySessionAsync(session, cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("Ely.by account '{Name}' signed in through OAuth.", session.Name);
     }
 
-    public async Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null)
+    public async Task SignInElyByAccountAsync(
+        string login,
+        string password,
+        string? twoFactorCode = null,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(login))
             throw new ArgumentException("Ely.by username or email cannot be empty.", nameof(login));
@@ -121,22 +129,29 @@ public sealed partial class AccountService
             throw new ArgumentException("Ely.by password cannot be empty.", nameof(password));
 
         EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
+        cancellationToken.ThrowIfCancellationRequested();
 
         _logger.LogInformation("Starting Ely.by sign-in for '{Login}'.", login);
         var session = await _elyByAuthClient
-            .AuthenticateAsync(login.Trim(), password, string.IsNullOrWhiteSpace(twoFactorCode) ? null : twoFactorCode.Trim())
+            .AuthenticateAsync(
+                login.Trim(),
+                password,
+                string.IsNullOrWhiteSpace(twoFactorCode) ? null : twoFactorCode.Trim(),
+                cancellationToken)
             .ConfigureAwait(false);
 
-        await AddOrUpdateElyBySessionAsync(session).ConfigureAwait(false);
+        await AddOrUpdateElyBySessionAsync(session, cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("Ely.by account '{Name}' signed in.", session.Name);
     }
 
-    private async Task AddOrUpdateElyBySessionAsync(ElyByAuthSession session)
+    private async Task AddOrUpdateElyBySessionAsync(ElyByAuthSession session, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var storedAccount = CreateStoredElyByAccount(session);
+        cancellationToken.ThrowIfCancellationRequested();
         _elyByAccountStore.Upsert(storedAccount);
 
-        await _gate.WaitAsync().ConfigureAwait(false);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             await _uiDispatcher.InvokeAsync(() =>

--- a/Emerald.CoreX/Services/AccountService.SignIn.cs
+++ b/Emerald.CoreX/Services/AccountService.SignIn.cs
@@ -1,0 +1,194 @@
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth.Microsoft;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services;
+
+public sealed partial class AccountService
+{
+    public void CreateOfflineAccount(string username)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+            throw new ArgumentException("Username cannot be empty.", nameof(username));
+
+        EnsureOfflineAccountPolicyMet("Creating offline accounts requires at least one Microsoft account.");
+
+        _gate.Wait();
+        try
+        {
+            _uiDispatcher.Invoke(() =>
+            {
+                if (_accounts.Any(account => account.Name.Equals(username, StringComparison.OrdinalIgnoreCase)))
+                    throw new InvalidOperationException($"An account named '{username}' already exists.");
+
+                var account = new EAccount(username, AccountType.Offline);
+                _accounts.Add(account);
+
+                if (GetSelectedAccountCore() is null)
+                    ApplySelectedAccountCore(account.UniqueId, persist: false);
+            });
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        PersistAccounts();
+        _logger.LogInformation("Created offline account '{Username}'.", username);
+    }
+
+    public async Task SignInMicrosoftAccountAsync()
+    {
+        await EnsureInitializedAsync().ConfigureAwait(false);
+
+        _logger.LogInformation("Starting interactive Microsoft sign-in.");
+        var beforeIdentifiers = _microsoftAccountClient
+            .GetAccounts()
+            .Select(account => account.Identifier)
+            .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync().ConfigureAwait(false);
+        _logger.LogInformation(
+            "Interactive Microsoft sign-in completed for '{Username}' (candidate identifier: {Identifier}).",
+            signInResult.Username ?? "Unknown",
+            signInResult.Identifier ?? "None");
+
+        var afterAccounts = _microsoftAccountClient.GetAccounts();
+        await LoadAllAccountsAsync().ConfigureAwait(false);
+
+        var candidateIdentifiers = BuildMaterializationCandidates(
+            signInResult,
+            beforeIdentifiers,
+            afterAccounts,
+            _microsoftAccountClient.GetDefaultAccountIdentifier());
+
+        EAccount? materializedAccount = null;
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await _uiDispatcher.InvokeAsync(() =>
+            {
+                materializedAccount = ResolveMaterializedMicrosoftAccountCore(candidateIdentifiers);
+                if (materializedAccount is null)
+                {
+                    throw new InvalidOperationException(
+                        "Microsoft sign-in completed, but Emerald could not materialize the signed-in account.");
+                }
+
+                if (GetSelectedAccountCore() is null)
+                    ApplySelectedAccountCore(materializedAccount.UniqueId, persist: true);
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        _logger.LogInformation(
+            "Microsoft account '{Name}' materialized with identifier '{Identifier}'.",
+            materializedAccount!.Name,
+            materializedAccount.UniqueId);
+    }
+
+    public async Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null)
+    {
+        if (string.IsNullOrWhiteSpace(login))
+            throw new ArgumentException("Ely.by username or email cannot be empty.", nameof(login));
+
+        if (string.IsNullOrWhiteSpace(password))
+            throw new ArgumentException("Ely.by password cannot be empty.", nameof(password));
+
+        EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
+
+        _logger.LogInformation("Starting Ely.by sign-in for '{Login}'.", login);
+        var session = await _elyByAuthClient
+            .AuthenticateAsync(login.Trim(), password, string.IsNullOrWhiteSpace(twoFactorCode) ? null : twoFactorCode.Trim())
+            .ConfigureAwait(false);
+
+        var storedAccount = CreateStoredElyByAccount(session);
+        _elyByAccountStore.Upsert(storedAccount);
+
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await _uiDispatcher.InvokeAsync(() =>
+            {
+                var account = _accounts.FirstOrDefault(candidate =>
+                    candidate.Type == AccountType.ElyBy &&
+                    string.Equals(candidate.UniqueId, storedAccount.UniqueId, StringComparison.Ordinal));
+
+                if (account is null)
+                {
+                    account = CreateElyByAccount(storedAccount);
+                    _accounts.Add(account);
+                }
+                else
+                {
+                    account.Name = storedAccount.Name;
+                    account.UUID = storedAccount.UUID;
+                    account.LastUsed = storedAccount.LastUsed;
+                    EnsureProviderId(account);
+                }
+
+                if (GetSelectedAccountCore() is null)
+                    ApplySelectedAccountCore(account.UniqueId, persist: false);
+            }).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        PersistAccounts();
+        _logger.LogInformation("Ely.by account '{Name}' signed in.", storedAccount.Name);
+    }
+
+    private static IReadOnlyList<string> BuildMaterializationCandidates(
+        MicrosoftInteractiveSignInResult signInResult,
+        ISet<string> beforeIdentifiers,
+        IReadOnlyList<MicrosoftAccountInfo> afterAccounts,
+        string? defaultAccountIdentifier)
+    {
+        var candidates = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        static void AddCandidate(List<string> candidates, HashSet<string> seen, string? identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier) || !seen.Add(identifier))
+                return;
+
+            candidates.Add(identifier);
+        }
+
+        AddCandidate(candidates, seen, signInResult.Identifier);
+        AddCandidate(candidates, seen, signInResult.UUID);
+
+        foreach (var addedAccount in afterAccounts
+                     .Where(account => !beforeIdentifiers.Contains(account.Identifier))
+                     .OrderByDescending(account => account.LastAccess))
+        {
+            AddCandidate(candidates, seen, addedAccount.Identifier);
+        }
+
+        AddCandidate(candidates, seen, defaultAccountIdentifier);
+        AddCandidate(candidates, seen, afterAccounts.OrderByDescending(account => account.LastAccess).FirstOrDefault()?.Identifier);
+
+        return candidates;
+    }
+
+    private EAccount? ResolveMaterializedMicrosoftAccountCore(IEnumerable<string> candidateIdentifiers)
+    {
+        foreach (var identifier in candidateIdentifiers)
+        {
+            var matched = _accounts.FirstOrDefault(account =>
+                account.Type == AccountType.Microsoft &&
+                string.Equals(account.UniqueId, identifier, StringComparison.Ordinal));
+
+            if (matched is not null)
+                return matched;
+        }
+
+        return null;
+    }
+}

--- a/Emerald.CoreX/Services/AccountService.cs
+++ b/Emerald.CoreX/Services/AccountService.cs
@@ -1,23 +1,32 @@
 using System.Collections.ObjectModel;
-using CmlLib.Core.Auth;
 using Emerald.CoreX.Helpers;
 using Emerald.CoreX.Models;
 using Emerald.CoreX.Notifications;
+using Emerald.CoreX.Services.Auth;
+using Emerald.CoreX.Services.Auth.Authlib;
+using Emerald.CoreX.Services.Auth.ElyBy;
+using Emerald.CoreX.Services.Auth.Microsoft;
+using Emerald.CoreX.Services.Auth.Offline;
 using Emerald.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Emerald.CoreX.Services;
 
-public sealed class AccountService : IAccountService
+public sealed partial class AccountService : IAccountService
 {
     public bool RequireMicrosoftAccountForOfflineAccounts => true;
+    public bool RequireMicrosoftAccountForElyByAccounts => true;
 
     private readonly ILogger<AccountService> _logger;
     private readonly IBaseSettingsService _settingsService;
     private readonly IUiDispatcher _uiDispatcher;
     private readonly IMicrosoftAccountClient _microsoftAccountClient;
+    private readonly IElyByAuthClient _elyByAuthClient;
+    private readonly IElyByAccountStore _elyByAccountStore;
     private readonly INotificationService? _notificationService;
     private readonly string _accountStorePath;
+    private readonly IReadOnlyDictionary<AccountType, IAccountAuthenticationProvider> _authenticationProviders;
 
     // Protects mutations of _accounts and _selectedAccountId.
     private readonly SemaphoreSlim _gate = new(1, 1);
@@ -43,20 +52,42 @@ public sealed class AccountService : IAccountService
         IUiDispatcher uiDispatcher,
         string? accountStorePath = null,
         IMicrosoftAccountClient? microsoftAccountClient = null,
-        INotificationService? notificationService = null)
+        INotificationService? notificationService = null,
+        IElyByAuthClient? elyByAuthClient = null,
+        IElyByAccountStore? elyByAccountStore = null,
+        IAuthlibInjectorService? authlibInjectorService = null,
+        IEnumerable<IAccountAuthenticationProvider>? authenticationProviders = null)
     {
         _logger = logger;
         _settingsService = settingsService;
         _uiDispatcher = uiDispatcher;
         _microsoftAccountClient = microsoftAccountClient ?? new CmlLibMicrosoftAccountClient(logger);
+        _elyByAuthClient = elyByAuthClient ?? new ElyByAuthClient(NullLogger<ElyByAuthClient>.Instance);
+        _elyByAccountStore = elyByAccountStore ?? new ElyByAccountStore(settingsService);
         _notificationService = notificationService;
         _accountStorePath = string.IsNullOrWhiteSpace(accountStorePath)
             ? GetDefaultAccountStorePath()
             : accountStorePath;
+        _authenticationProviders = (authenticationProviders ?? CreateDefaultAuthenticationProviders(authlibInjectorService))
+            .ToDictionary(provider => provider.AccountType);
         _selectedAccountId = _settingsService.Get<string?>(SettingsKeys.SelectedMinecraftAccount, null);
     }
 
     public ObservableCollection<EAccount> Accounts => _accounts;
+
+    private IReadOnlyList<IAccountAuthenticationProvider> CreateDefaultAuthenticationProviders(
+        IAuthlibInjectorService? authlibInjectorService)
+    {
+        var authlib = authlibInjectorService
+            ?? new AuthlibInjectorService(NullLogger<AuthlibInjectorService>.Instance);
+
+        return
+        [
+            new OfflineAccountAuthenticationProvider(),
+            new MicrosoftAccountAuthenticationProvider(_microsoftAccountClient),
+            new ElyByAccountAuthenticationProvider(_elyByAccountStore, _elyByAuthClient, authlib)
+        ];
+    }
 
     public Task InitializeAsync(string clientId)
     {
@@ -68,279 +99,6 @@ public sealed class AccountService : IAccountService
             }
 
             return _initializationTask;
-        }
-    }
-
-    public async Task LoadAllAccountsAsync()
-    {
-        await EnsureInitializedAsync().ConfigureAwait(false);
-        await _loadGate.WaitAsync().ConfigureAwait(false);
-
-        try
-        {
-            _logger.LogInformation("Loading accounts from Emerald settings and the CmlLib account store.");
-            var loadState = BuildAccountLoadState();
-
-            _logger.LogInformation(
-                "Found {OfflineCount} offline accounts and {StoredMicrosoftCount} stored Microsoft accounts in settings, and found {OnlineCount} Microsoft accounts in CmlLib.",
-                loadState.OfflineCount,
-                loadState.StoredMicrosoftCount,
-                loadState.MicrosoftCount);
-
-            await _gate.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                await _uiDispatcher.InvokeAsync(() =>
-                {
-                    ApplyLoadedAccountsCore(loadState.Accounts);
-                }).ConfigureAwait(false);
-            }
-            finally
-            {
-                _gate.Release();
-            }
-
-            PersistAccounts();
-            NotifyLoggedOutMicrosoftAccounts(loadState.LoggedOutMicrosoftAccountNames);
-            _logger.LogInformation(
-                "Loaded {TotalCount} accounts ({OfflineCount} offline, {MicrosoftCount} Microsoft). Logged out Microsoft accounts detected: {LoggedOutMicrosoftCount}.",
-                loadState.TotalCount,
-                loadState.OfflineCount,
-                loadState.MicrosoftCount,
-                loadState.LoggedOutMicrosoftCount);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to load accounts.");
-            throw;
-        }
-        finally
-        {
-            _loadGate.Release();
-        }
-    }
-
-    public void CreateOfflineAccount(string username)
-    {
-        if (string.IsNullOrWhiteSpace(username))
-            throw new ArgumentException("Username cannot be empty.", nameof(username));
-
-        EnsureOfflineAccountPolicyMet("Creating offline accounts requires at least one Microsoft account.");
-
-        _gate.Wait();
-        try
-        {
-            _uiDispatcher.Invoke(() =>
-            {
-                if (_accounts.Any(account => account.Name.Equals(username, StringComparison.OrdinalIgnoreCase)))
-                    throw new InvalidOperationException($"An account named '{username}' already exists.");
-
-                var account = new EAccount(username, AccountType.Offline);
-                _accounts.Add(account);
-
-                if (GetSelectedAccountCore() is null)
-                    ApplySelectedAccountCore(account.UniqueId, persist: false);
-            });
-        }
-        finally
-        {
-            _gate.Release();
-        }
-
-        PersistAccounts();
-        _logger.LogInformation("Created offline account '{Username}'.", username);
-    }
-
-    public async Task SignInMicrosoftAccountAsync()
-    {
-        await EnsureInitializedAsync().ConfigureAwait(false);
-
-        _logger.LogInformation("Starting interactive Microsoft sign-in.");
-        var beforeIdentifiers = _microsoftAccountClient
-            .GetAccounts()
-            .Select(account => account.Identifier)
-            .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
-            .ToHashSet(StringComparer.Ordinal);
-
-        var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync().ConfigureAwait(false);
-        _logger.LogInformation(
-            "Interactive Microsoft sign-in completed for '{Username}' (candidate identifier: {Identifier}).",
-            signInResult.Username ?? "Unknown",
-            signInResult.Identifier ?? "None");
-
-        var afterAccounts = _microsoftAccountClient.GetAccounts();
-        await LoadAllAccountsAsync().ConfigureAwait(false);
-
-        var candidateIdentifiers = BuildMaterializationCandidates(
-            signInResult,
-            beforeIdentifiers,
-            afterAccounts,
-            _microsoftAccountClient.GetDefaultAccountIdentifier());
-
-        EAccount? materializedAccount = null;
-        await _gate.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            await _uiDispatcher.InvokeAsync(() =>
-            {
-                materializedAccount = ResolveMaterializedMicrosoftAccountCore(candidateIdentifiers);
-                if (materializedAccount is null)
-                {
-                    throw new InvalidOperationException(
-                        "Microsoft sign-in completed, but Emerald could not materialize the signed-in account.");
-                }
-
-                if (GetSelectedAccountCore() is null)
-                    ApplySelectedAccountCore(materializedAccount.UniqueId, persist: true);
-            }).ConfigureAwait(false);
-        }
-        finally
-        {
-            _gate.Release();
-        }
-
-        _logger.LogInformation(
-            "Microsoft account '{Name}' materialized with identifier '{Identifier}'.",
-            materializedAccount!.Name,
-            materializedAccount.UniqueId);
-    }
-
-    public async Task RemoveAccountAsync(EAccount account)
-    {
-        _logger.LogInformation("Removing account '{Name}' ({Type}).", account.Name, account.Type);
-
-        if (account.Type == AccountType.Microsoft)
-        {
-            await EnsureInitializedAsync().ConfigureAwait(false);
-            await _microsoftAccountClient.SignOutAsync(account.UniqueId).ConfigureAwait(false);
-            _logger.LogInformation("Signed out Microsoft account '{Name}' ({Identifier}).", account.Name, account.UniqueId);
-            await LoadAllAccountsAsync().ConfigureAwait(false);
-            return;
-        }
-
-        var wasSelected = false;
-        await _gate.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            await _uiDispatcher.InvokeAsync(() =>
-            {
-                wasSelected = string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal);
-                _accounts.Remove(account);
-
-                if (wasSelected)
-                    ApplySelectedAccountCore(null, persist: false);
-
-                EnforceOfflineSelectionPolicyCore(persist: false);
-            }).ConfigureAwait(false);
-        }
-        finally
-        {
-            _gate.Release();
-        }
-
-        PersistAccounts();
-    }
-
-    public async Task<MSession> AuthenticateAccountAsync(EAccount account)
-    {
-        _logger.LogInformation("Authenticating '{Name}' ({Type}).", account.Name, account.Type);
-
-        MSession session;
-
-        if (account.Type == AccountType.Offline)
-        {
-            EnsureOfflineAccountPolicyMet("Offline accounts require at least one Microsoft account.");
-            session = MSession.CreateOfflineSession(account.Name);
-        }
-        else if (account.Type == AccountType.Microsoft)
-        {
-            await EnsureInitializedAsync().ConfigureAwait(false);
-            session = await _microsoftAccountClient.AuthenticateAsync(account.UniqueId).ConfigureAwait(false);
-        }
-        else
-        {
-            throw new ArgumentException($"Unknown account type: {account.Type}");
-        }
-
-        await _gate.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            await _uiDispatcher.InvokeAsync(() =>
-            {
-                var matched = _accounts.FirstOrDefault(candidate =>
-                    ReferenceEquals(candidate, account) ||
-                    string.Equals(candidate.UniqueId, account.UniqueId, StringComparison.Ordinal));
-
-                if (matched is not null)
-                    matched.LastUsed = DateTime.UtcNow;
-            }).ConfigureAwait(false);
-        }
-        finally
-        {
-            _gate.Release();
-        }
-
-        PersistAccounts();
-        return session;
-    }
-
-    public EAccount? GetMostRecentlyUsedAccount()
-    {
-        EAccount? account = null;
-        _uiDispatcher.Invoke(() =>
-        {
-            account = _accounts.Count == 0
-                ? null
-                : _accounts.OrderByDescending(candidate => candidate.LastUsed).First();
-        });
-
-        return account;
-    }
-
-    public EAccount? GetSelectedAccount()
-    {
-        EAccount? account = null;
-        _uiDispatcher.Invoke(() => account = GetSelectedAccountCore());
-        return account;
-    }
-
-    public void SetSelectedAccount(EAccount? account)
-    {
-        _gate.Wait();
-        try
-        {
-            _uiDispatcher.Invoke(() =>
-            {
-                if (account is null)
-                {
-                    ApplySelectedAccountCore(null, persist: true);
-                    return;
-                }
-
-                var matched = _accounts.FirstOrDefault(candidate =>
-                    ReferenceEquals(candidate, account) ||
-                    string.Equals(candidate.UniqueId, account.UniqueId, StringComparison.Ordinal));
-
-                if (matched is null)
-                {
-                    _logger.LogWarning(
-                        "SetSelectedAccount: account '{Name}' (id={Id}) not found in the collection.",
-                        account.Name,
-                        account.UniqueId);
-                    return;
-                }
-
-                matched = EnsureUniqueId(matched);
-
-                if (matched.Type == AccountType.Offline)
-                    EnsureOfflineAccountPolicyMet("Selecting an offline account requires at least one Microsoft account.");
-
-                ApplySelectedAccountCore(matched.UniqueId, persist: true);
-            });
-        }
-        finally
-        {
-            _gate.Release();
         }
     }
 
@@ -383,248 +141,6 @@ public sealed class AccountService : IAccountService
         await task.ConfigureAwait(false);
     }
 
-    private void RestoreSelectedAccountCore()
-    {
-        _selectedAccountId = _settingsService.Get<string?>(SettingsKeys.SelectedMinecraftAccount, null);
-
-        if (!string.IsNullOrWhiteSpace(_selectedAccountId) && GetSelectedAccountCore() is null)
-        {
-            _logger.LogInformation("Previously selected account no longer exists; clearing selection.");
-            ApplySelectedAccountCore(null, persist: false);
-            return;
-        }
-
-        ApplySelectedAccountCore(_selectedAccountId, persist: false);
-    }
-
-    private EAccount? GetSelectedAccountCore()
-        => string.IsNullOrWhiteSpace(_selectedAccountId)
-            ? null
-            : _accounts.FirstOrDefault(account =>
-                string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal));
-
-    private void ApplySelectedAccountCore(string? uniqueId, bool persist)
-    {
-        _selectedAccountId = string.IsNullOrWhiteSpace(uniqueId) ? null : uniqueId;
-
-        foreach (var account in _accounts)
-            account.IsSelected = string.Equals(account.UniqueId, _selectedAccountId, StringComparison.Ordinal);
-
-        if (persist)
-            _settingsService.Set(SettingsKeys.SelectedMinecraftAccount, _selectedAccountId);
-    }
-
-    private bool HasMicrosoftAccountCore()
-        => _accounts.Any(account => account.Type == AccountType.Microsoft);
-
-    private bool IsOfflineAccountAllowed()
-        => !RequireMicrosoftAccountForOfflineAccounts || HasMicrosoftAccountCore();
-
-    private void EnsureOfflineAccountPolicyMet(string message)
-    {
-        if (!IsOfflineAccountAllowed())
-            throw new InvalidOperationException(message);
-    }
-
-    private void EnforceOfflineSelectionPolicyCore(bool persist)
-    {
-        if (IsOfflineAccountAllowed())
-            return;
-
-        if (GetSelectedAccountCore()?.Type == AccountType.Offline)
-        {
-            _logger.LogInformation("Clearing offline account selection due to policy.");
-            ApplySelectedAccountCore(null, persist);
-        }
-    }
-
-    private void PersistAccounts()
-    {
-        try
-        {
-            List<EAccount> storedAccounts = [];
-            string? selectedAccountId = null;
-            _uiDispatcher.Invoke(() =>
-            {
-                storedAccounts = _accounts
-                    .Select(CloneStoredAccount)
-                    .ToList();
-                selectedAccountId = _selectedAccountId;
-            });
-
-            _settingsService.Set(SettingsKeys.MinecraftAccounts, storedAccounts);
-            _settingsService.Set(SettingsKeys.SelectedMinecraftAccount, selectedAccountId);
-            var offlineCount = storedAccounts.Count(account => account.Type == AccountType.Offline);
-            var microsoftCount = storedAccounts.Count(account => account.Type == AccountType.Microsoft);
-            _logger.LogDebug(
-                "Persisted {TotalCount} accounts ({OfflineCount} offline, {MicrosoftCount} Microsoft). SelectedAccountId: {SelectedAccountId}.",
-                storedAccounts.Count,
-                offlineCount,
-                microsoftCount,
-                selectedAccountId ?? "None");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to persist accounts.");
-            throw;
-        }
-    }
-
-    private EAccount EnsureUniqueId(EAccount account)
-    {
-        if (string.IsNullOrWhiteSpace(account.UniqueId))
-        {
-            account.UniqueId = Guid.NewGuid().ToString();
-            _logger.LogInformation(
-                "Generated missing UniqueId for account '{Name}' ({Type}).",
-                account.Name,
-                account.Type);
-        }
-
-        return account;
-    }
-
-    private EAccount CloneStoredAccount(EAccount account)
-    {
-        var storedAccount = EnsureUniqueId(account);
-        return new EAccount(storedAccount.Name, storedAccount.Type, storedAccount.UUID, storedAccount.UniqueId)
-        {
-            LastUsed = storedAccount.LastUsed
-        };
-    }
-
-    private AccountLoadState BuildAccountLoadState()
-    {
-        var storedAccounts = _settingsService.Get(SettingsKeys.MinecraftAccounts, new List<EAccount>());
-        var offlineAccounts = storedAccounts
-            .Where(account => account.Type == AccountType.Offline)
-            .Select(CloneStoredAccount)
-            .ToList();
-        var storedMicrosoftAccounts = storedAccounts
-            .Where(account => account.Type == AccountType.Microsoft)
-            .Select(CloneStoredAccount)
-            .ToList();
-        var onlineMicrosoftAccounts = _microsoftAccountClient.GetAccounts()
-            .Where(account =>
-            {
-                if (!string.IsNullOrWhiteSpace(account.Identifier))
-                    return true;
-
-                _logger.LogWarning("Skipping a Microsoft account with a missing identifier.");
-                return false;
-            })
-            .Select(CreateMicrosoftAccount)
-            .ToList();
-
-        var onlineIdentifiers = new HashSet<string>(
-            onlineMicrosoftAccounts.Select(account => account.UniqueId),
-            StringComparer.Ordinal);
-        var loggedOutAccountNames = storedMicrosoftAccounts
-            .Where(account => !onlineIdentifiers.Contains(account.UniqueId))
-            .Select(account => account.Name)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var loadedAccounts = new List<EAccount>(offlineAccounts.Count + onlineMicrosoftAccounts.Count);
-        loadedAccounts.AddRange(offlineAccounts);
-        loadedAccounts.AddRange(onlineMicrosoftAccounts);
-
-        return new AccountLoadState(
-            loadedAccounts,
-            offlineAccounts.Count,
-            storedMicrosoftAccounts.Count,
-            onlineMicrosoftAccounts.Count,
-            loggedOutAccountNames);
-    }
-
-    private void NotifyLoggedOutMicrosoftAccounts(IReadOnlyList<string> loggedOutMicrosoftAccountNames)
-    {
-        if (_notificationService is null || loggedOutMicrosoftAccountNames.Count == 0)
-            return;
-
-        if (loggedOutMicrosoftAccountNames.Count == 1)
-        {
-            _notificationService.Warning(
-                "Microsoft account signed out",
-                $"'{loggedOutMicrosoftAccountNames[0]}' is no longer signed in and was removed from Accounts.");
-            return;
-        }
-
-        _notificationService.Warning(
-            "Microsoft accounts signed out",
-            $"{loggedOutMicrosoftAccountNames.Count} Microsoft accounts are no longer signed in and were removed from Accounts.");
-    }
-
-    private static EAccount CreateMicrosoftAccount(MicrosoftAccountInfo account)
-        => new(
-            account.Name,
-            AccountType.Microsoft,
-            string.IsNullOrWhiteSpace(account.UUID) ? account.Identifier : account.UUID,
-            account.Identifier)
-        {
-            LastUsed = account.LastAccess == default ? DateTime.UtcNow : account.LastAccess
-        };
-
-    private void ApplyLoadedAccountsCore(IEnumerable<EAccount> accounts)
-    {
-        _accounts.Clear();
-
-        foreach (var account in accounts)
-            _accounts.Add(account);
-
-        RestoreSelectedAccountCore();
-        EnforceOfflineSelectionPolicyCore(persist: false);
-    }
-
-    private static IReadOnlyList<string> BuildMaterializationCandidates(
-        MicrosoftInteractiveSignInResult signInResult,
-        ISet<string> beforeIdentifiers,
-        IReadOnlyList<MicrosoftAccountInfo> afterAccounts,
-        string? defaultAccountIdentifier)
-    {
-        var candidates = new List<string>();
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-
-        static void AddCandidate(List<string> candidates, HashSet<string> seen, string? identifier)
-        {
-            if (string.IsNullOrWhiteSpace(identifier) || !seen.Add(identifier))
-                return;
-
-            candidates.Add(identifier);
-        }
-
-        AddCandidate(candidates, seen, signInResult.Identifier);
-        AddCandidate(candidates, seen, signInResult.UUID);
-
-        foreach (var addedAccount in afterAccounts
-                     .Where(account => !beforeIdentifiers.Contains(account.Identifier))
-                     .OrderByDescending(account => account.LastAccess))
-        {
-            AddCandidate(candidates, seen, addedAccount.Identifier);
-        }
-
-        AddCandidate(candidates, seen, defaultAccountIdentifier);
-        AddCandidate(candidates, seen, afterAccounts.OrderByDescending(account => account.LastAccess).FirstOrDefault()?.Identifier);
-
-        return candidates;
-    }
-
-    private EAccount? ResolveMaterializedMicrosoftAccountCore(IEnumerable<string> candidateIdentifiers)
-    {
-        foreach (var identifier in candidateIdentifiers)
-        {
-            var matched = _accounts.FirstOrDefault(account =>
-                account.Type == AccountType.Microsoft &&
-                string.Equals(account.UniqueId, identifier, StringComparison.Ordinal));
-
-            if (matched is not null)
-                return matched;
-        }
-
-        return null;
-    }
-
     private static string GetDefaultAccountStorePath()
         => Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -637,6 +153,7 @@ public sealed class AccountService : IAccountService
         int OfflineCount,
         int StoredMicrosoftCount,
         int MicrosoftCount,
+        int ElyByCount,
         IReadOnlyList<string> LoggedOutMicrosoftAccountNames)
     {
         public int TotalCount => Accounts.Count;

--- a/Emerald.CoreX/Services/AccountService.cs
+++ b/Emerald.CoreX/Services/AccountService.cs
@@ -15,8 +15,8 @@ namespace Emerald.CoreX.Services;
 
 public sealed partial class AccountService : IAccountService
 {
-    public bool RequireMicrosoftAccountForOfflineAccounts => true;
-    public bool RequireMicrosoftAccountForElyByAccounts => true;
+    public bool RequireMicrosoftAccountForOfflineAccounts => false;
+    public bool RequireMicrosoftAccountForElyByAccounts => false;
 
     private readonly ILogger<AccountService> _logger;
     private readonly IBaseSettingsService _settingsService;

--- a/Emerald.CoreX/Services/AccountService.cs
+++ b/Emerald.CoreX/Services/AccountService.cs
@@ -24,6 +24,7 @@ public sealed partial class AccountService : IAccountService
     private readonly IMicrosoftAccountClient _microsoftAccountClient;
     private readonly IElyByAuthClient _elyByAuthClient;
     private readonly IElyByAccountStore _elyByAccountStore;
+    private readonly IElyByOAuthBrowser _elyByOAuthBrowser;
     private readonly INotificationService? _notificationService;
     private readonly string _accountStorePath;
     private readonly IReadOnlyDictionary<AccountType, IAccountAuthenticationProvider> _authenticationProviders;
@@ -55,6 +56,7 @@ public sealed partial class AccountService : IAccountService
         INotificationService? notificationService = null,
         IElyByAuthClient? elyByAuthClient = null,
         IElyByAccountStore? elyByAccountStore = null,
+        IElyByOAuthBrowser? elyByOAuthBrowser = null,
         IAuthlibInjectorService? authlibInjectorService = null,
         IEnumerable<IAccountAuthenticationProvider>? authenticationProviders = null)
     {
@@ -64,6 +66,7 @@ public sealed partial class AccountService : IAccountService
         _microsoftAccountClient = microsoftAccountClient ?? new CmlLibMicrosoftAccountClient(logger);
         _elyByAuthClient = elyByAuthClient ?? new ElyByAuthClient(NullLogger<ElyByAuthClient>.Instance);
         _elyByAccountStore = elyByAccountStore ?? new ElyByAccountStore(settingsService);
+        _elyByOAuthBrowser = elyByOAuthBrowser ?? new UnsupportedElyByOAuthBrowser();
         _notificationService = notificationService;
         _accountStorePath = string.IsNullOrWhiteSpace(accountStorePath)
             ? GetDefaultAccountStorePath()

--- a/Emerald.CoreX/Services/Auth/AccountProviderIds.cs
+++ b/Emerald.CoreX/Services/Auth/AccountProviderIds.cs
@@ -1,0 +1,19 @@
+using Emerald.CoreX.Models;
+
+namespace Emerald.CoreX.Services.Auth;
+
+public static class AccountProviderIds
+{
+    public const string Offline = "offline";
+    public const string Microsoft = "microsoft";
+    public const string ElyBy = "elyby";
+
+    public static string FromAccountType(AccountType type)
+        => type switch
+        {
+            AccountType.Offline => Offline,
+            AccountType.Microsoft => Microsoft,
+            AccountType.ElyBy => ElyBy,
+            _ => type.ToString()
+        };
+}

--- a/Emerald.CoreX/Services/Auth/AccountRuntimeAuthOptions.cs
+++ b/Emerald.CoreX/Services/Auth/AccountRuntimeAuthOptions.cs
@@ -1,0 +1,8 @@
+using CmlLib.Core.ProcessBuilder;
+
+namespace Emerald.CoreX.Services.Auth;
+
+public sealed record AccountRuntimeAuthOptions(IReadOnlyList<MArgument> ExtraJvmArguments)
+{
+    public static AccountRuntimeAuthOptions Empty { get; } = new([]);
+}

--- a/Emerald.CoreX/Services/Auth/Authlib/AuthlibInjectorService.cs
+++ b/Emerald.CoreX/Services/Auth/Authlib/AuthlibInjectorService.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services.Auth.Authlib;
+
+public sealed class AuthlibInjectorService : IAuthlibInjectorService
+{
+    private const string Version = "1.2.7";
+    private const string FileName = $"authlib-injector-{Version}.jar";
+    private const string DownloadUrl = $"https://github.com/yushijinhun/authlib-injector/releases/download/v{Version}/{FileName}";
+
+    private readonly ILogger<AuthlibInjectorService> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly string _baseDirectory;
+
+    public AuthlibInjectorService(
+        ILogger<AuthlibInjectorService> logger,
+        string? baseDirectory = null,
+        HttpClient? httpClient = null)
+    {
+        _logger = logger;
+        _httpClient = httpClient ?? new HttpClient();
+        _baseDirectory = string.IsNullOrWhiteSpace(baseDirectory)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Emerald", "authlib-injector")
+            : baseDirectory;
+    }
+
+    public async Task<string> GetJavaAgentArgumentAsync(CancellationToken cancellationToken = default)
+    {
+        var jarPath = await EnsureJarAsync(cancellationToken).ConfigureAwait(false);
+        return $"-javaagent:{jarPath}=ely.by";
+    }
+
+    private async Task<string> EnsureJarAsync(CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(_baseDirectory);
+
+        var jarPath = Path.Combine(_baseDirectory, FileName);
+        if (File.Exists(jarPath))
+            return jarPath;
+
+        var tempPath = jarPath + ".tmp";
+        _logger.LogInformation("Downloading authlib-injector {Version} to {Path}.", Version, jarPath);
+
+        using var response = await _httpClient
+            .GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using (var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+        await using (var destination = File.Create(tempPath))
+        {
+            await source.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (File.Exists(jarPath))
+            File.Delete(jarPath);
+
+        File.Move(tempPath, jarPath);
+        return jarPath;
+    }
+}

--- a/Emerald.CoreX/Services/Auth/Authlib/IAuthlibInjectorService.cs
+++ b/Emerald.CoreX/Services/Auth/Authlib/IAuthlibInjectorService.cs
@@ -1,0 +1,6 @@
+namespace Emerald.CoreX.Services.Auth.Authlib;
+
+public interface IAuthlibInjectorService
+{
+    Task<string> GetJavaAgentArgumentAsync(CancellationToken cancellationToken = default);
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountAuthenticationProvider.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountAuthenticationProvider.cs
@@ -20,7 +20,23 @@ internal sealed class ElyByAccountAuthenticationProvider(
             ?? throw new InvalidOperationException($"Ely.by account '{account.Name}' is no longer signed in.");
 
         ElyByAuthSession session;
-        if (await authClient.ValidateAsync(storedAccount.AccessToken, storedAccount.ClientToken, cancellationToken).ConfigureAwait(false))
+        if (storedAccount.AuthFlow == ElyByAuthFlow.OAuth)
+        {
+            var shouldRefresh = storedAccount.AccessTokenExpiresAt is null ||
+                                storedAccount.AccessTokenExpiresAt <= DateTimeOffset.UtcNow.AddMinutes(1);
+
+            session = shouldRefresh
+                ? await authClient.RefreshAsync(storedAccount, cancellationToken).ConfigureAwait(false)
+                : new ElyByAuthSession(
+                    storedAccount.Name,
+                    storedAccount.UUID,
+                    storedAccount.AccessToken,
+                    storedAccount.ClientToken,
+                    storedAccount.RefreshToken,
+                    storedAccount.AccessTokenExpiresAt,
+                    ElyByAuthFlow.OAuth);
+        }
+        else if (await authClient.ValidateAsync(storedAccount.AccessToken, storedAccount.ClientToken, cancellationToken).ConfigureAwait(false))
         {
             session = new ElyByAuthSession(storedAccount.Name, storedAccount.UUID, storedAccount.AccessToken, storedAccount.ClientToken);
         }
@@ -33,6 +49,9 @@ internal sealed class ElyByAccountAuthenticationProvider(
         storedAccount.UUID = session.UUID;
         storedAccount.AccessToken = session.AccessToken;
         storedAccount.ClientToken = session.ClientToken;
+        storedAccount.RefreshToken = session.RefreshToken ?? storedAccount.RefreshToken;
+        storedAccount.AccessTokenExpiresAt = session.AccessTokenExpiresAt;
+        storedAccount.AuthFlow = session.AuthFlow;
         storedAccount.LastUsed = DateTime.UtcNow;
         accountStore.Upsert(storedAccount);
 

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountAuthenticationProvider.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountAuthenticationProvider.cs
@@ -1,0 +1,64 @@
+using CmlLib.Core.Auth;
+using CmlLib.Core.ProcessBuilder;
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+using Emerald.CoreX.Services.Auth.Authlib;
+
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed class ElyByAccountAuthenticationProvider(
+    IElyByAccountStore accountStore,
+    IElyByAuthClient authClient,
+    IAuthlibInjectorService authlibInjectorService) : IAccountAuthenticationProvider
+{
+    public AccountType AccountType => AccountType.ElyBy;
+    public string ProviderId => AccountProviderIds.ElyBy;
+
+    public async Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default)
+    {
+        var storedAccount = accountStore.Find(account.UniqueId)
+            ?? throw new InvalidOperationException($"Ely.by account '{account.Name}' is no longer signed in.");
+
+        ElyByAuthSession session;
+        if (await authClient.ValidateAsync(storedAccount.AccessToken, storedAccount.ClientToken, cancellationToken).ConfigureAwait(false))
+        {
+            session = new ElyByAuthSession(storedAccount.Name, storedAccount.UUID, storedAccount.AccessToken, storedAccount.ClientToken);
+        }
+        else
+        {
+            session = await authClient.RefreshAsync(storedAccount, cancellationToken).ConfigureAwait(false);
+        }
+
+        storedAccount.Name = session.Name;
+        storedAccount.UUID = session.UUID;
+        storedAccount.AccessToken = session.AccessToken;
+        storedAccount.ClientToken = session.ClientToken;
+        storedAccount.LastUsed = DateTime.UtcNow;
+        accountStore.Upsert(storedAccount);
+
+        var javaAgentArgument = await authlibInjectorService.GetJavaAgentArgumentAsync(cancellationToken).ConfigureAwait(false);
+        var runtimeOptions = new AccountRuntimeAuthOptions([new MArgument(javaAgentArgument)]);
+
+        return new GameAuthenticationResult(
+            new MSession
+            {
+                Username = session.Name,
+                UUID = session.UUID,
+                AccessToken = session.AccessToken,
+                ClientToken = session.ClientToken,
+                UserType = "msa"
+            },
+            runtimeOptions);
+    }
+
+    public async Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default)
+    {
+        var storedAccount = accountStore.Find(account.UniqueId);
+        if (storedAccount is not null)
+        {
+            await authClient.InvalidateAsync(storedAccount, cancellationToken).ConfigureAwait(false);
+        }
+
+        accountStore.Remove(account.UniqueId);
+    }
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountStore.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAccountStore.cs
@@ -1,0 +1,37 @@
+using Emerald.CoreX.Helpers;
+using Emerald.Services;
+
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed class ElyByAccountStore(IBaseSettingsService settingsService) : IElyByAccountStore
+{
+    public IReadOnlyList<ElyByStoredAccount> GetAccounts()
+        => settingsService.Get(SettingsKeys.ElyByAccounts, new List<ElyByStoredAccount>())
+            .Where(account => !string.IsNullOrWhiteSpace(account.UniqueId))
+            .ToList();
+
+    public ElyByStoredAccount? Find(string uniqueId)
+        => GetAccounts().FirstOrDefault(account => string.Equals(account.UniqueId, uniqueId, StringComparison.Ordinal));
+
+    public void Upsert(ElyByStoredAccount account)
+    {
+        var accounts = GetAccounts().ToList();
+        var index = accounts.FindIndex(candidate => string.Equals(candidate.UniqueId, account.UniqueId, StringComparison.Ordinal));
+
+        if (index >= 0)
+            accounts[index] = account;
+        else
+            accounts.Add(account);
+
+        settingsService.Set(SettingsKeys.ElyByAccounts, accounts);
+    }
+
+    public void Remove(string uniqueId)
+    {
+        var accounts = GetAccounts()
+            .Where(account => !string.Equals(account.UniqueId, uniqueId, StringComparison.Ordinal))
+            .ToList();
+
+        settingsService.Set(SettingsKeys.ElyByAccounts, accounts);
+    }
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthClient.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -8,17 +9,67 @@ namespace Emerald.CoreX.Services.Auth.ElyBy;
 
 internal sealed class ElyByAuthClient : IElyByAuthClient
 {
-    private static readonly Uri BaseUri = new("https://authserver.ely.by/");
+    private static readonly Uri AuthServerBaseUri = new("https://authserver.ely.by/");
+    private static readonly Uri AccountBaseUri = new("https://account.ely.by/");
+    private static readonly Uri OAuthTokenEndpoint = new(AccountBaseUri, "api/oauth2/v1/token");
+    private static readonly Uri AccountInfoEndpoint = new(AccountBaseUri, "api/account/v1/info");
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly ILogger<ElyByAuthClient> _logger;
     private readonly HttpClient _httpClient;
+    private readonly ElyByOAuthOptions? _oauthOptions;
 
-    public ElyByAuthClient(ILogger<ElyByAuthClient> logger, HttpClient? httpClient = null)
+    public ElyByAuthClient(
+        ILogger<ElyByAuthClient> logger,
+        ElyByOAuthOptions? oauthOptions = null,
+        HttpClient? httpClient = null)
     {
         _logger = logger;
+        _oauthOptions = oauthOptions;
         _httpClient = httpClient ?? new HttpClient();
-        _httpClient.BaseAddress ??= BaseUri;
+    }
+
+    public ElyByOAuthAuthorizationRequest CreateOAuthAuthorizationRequest(string state, string? loginHint = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(state);
+        var oauthOptions = GetConfiguredOAuthOptions();
+        var redirectUri = new Uri(oauthOptions.RedirectUri, UriKind.Absolute);
+
+        var parameters = new List<(string Key, string? Value)>
+        {
+            ("client_id", oauthOptions.ClientId),
+            ("redirect_uri", oauthOptions.RedirectUri),
+            ("response_type", "code"),
+            ("scope", oauthOptions.Scope),
+            ("state", state)
+        };
+
+        if (!string.IsNullOrWhiteSpace(loginHint))
+            parameters.Add(("login_hint", loginHint));
+
+        var authorizationUri = new Uri(AccountBaseUri, "oauth2/v1?" + BuildQuery(parameters));
+        return new ElyByOAuthAuthorizationRequest(authorizationUri, redirectUri, state);
+    }
+
+    public async Task<ElyByAuthSession> ExchangeOAuthCodeAsync(
+        string code,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        var oauthOptions = GetConfiguredOAuthOptions();
+        var response = await SendOAuthTokenRequestAsync(
+                new Dictionary<string, string>
+                {
+                    ["client_id"] = oauthOptions.ClientId,
+                    ["client_secret"] = oauthOptions.ClientSecret,
+                    ["redirect_uri"] = oauthOptions.RedirectUri,
+                    ["grant_type"] = "authorization_code",
+                    ["code"] = code
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return await CreateOAuthSessionAsync(response, fallbackRefreshToken: null, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<ElyByAuthSession> AuthenticateAsync(
@@ -48,7 +99,7 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
         CancellationToken cancellationToken = default)
     {
         var response = await _httpClient.PostAsJsonAsync(
-                "auth/validate",
+                new Uri(AuthServerBaseUri, "auth/validate"),
                 new ElyByTokenRequest(accessToken, clientToken),
                 JsonOptions,
                 cancellationToken)
@@ -68,6 +119,11 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
         ElyByStoredAccount account,
         CancellationToken cancellationToken = default)
     {
+        if (account.AuthFlow == ElyByAuthFlow.OAuth && !string.IsNullOrWhiteSpace(account.RefreshToken))
+        {
+            return await RefreshOAuthAsync(account, cancellationToken).ConfigureAwait(false);
+        }
+
         var response = await SendAsync<ElyByTokenRequest, ElyByAuthResponse>(
                 "auth/refresh",
                 new ElyByTokenRequest(account.AccessToken, account.ClientToken),
@@ -81,8 +137,14 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
         ElyByStoredAccount account,
         CancellationToken cancellationToken = default)
     {
+        if (account.AuthFlow == ElyByAuthFlow.OAuth)
+        {
+            _logger.LogDebug("Skipping remote Ely.by OAuth token invalidation for {AccountName}; no OAuth revoke endpoint is documented.", account.Name);
+            return;
+        }
+
         var response = await _httpClient.PostAsJsonAsync(
-                "auth/invalidate",
+                new Uri(AuthServerBaseUri, "auth/invalidate"),
                 new ElyByTokenRequest(account.AccessToken, account.ClientToken),
                 JsonOptions,
                 cancellationToken)
@@ -117,7 +179,7 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
         TRequest request,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.PostAsJsonAsync(path, request, JsonOptions, cancellationToken)
+        using var response = await _httpClient.PostAsJsonAsync(new Uri(AuthServerBaseUri, path), request, JsonOptions, cancellationToken)
             .ConfigureAwait(false);
 
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -132,6 +194,94 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
             throw new ElyByTwoFactorRequiredException();
 
         throw new ElyByAuthException(error?.ErrorMessage ?? error?.Error ?? $"Ely.by request failed with status {(int)response.StatusCode}.");
+    }
+
+    private async Task<ElyByAuthSession> RefreshOAuthAsync(
+        ElyByStoredAccount account,
+        CancellationToken cancellationToken)
+    {
+        var oauthOptions = GetConfiguredOAuthOptions();
+        var response = await SendOAuthTokenRequestAsync(
+                new Dictionary<string, string>
+                {
+                    ["client_id"] = oauthOptions.ClientId,
+                    ["client_secret"] = oauthOptions.ClientSecret,
+                    ["scope"] = oauthOptions.Scope,
+                    ["refresh_token"] = account.RefreshToken,
+                    ["grant_type"] = "refresh_token"
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return await CreateOAuthSessionAsync(response, account.RefreshToken, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<ElyByOAuthTokenResponse> SendOAuthTokenRequestAsync(
+        IReadOnlyDictionary<string, string> parameters,
+        CancellationToken cancellationToken)
+    {
+        using var content = new FormUrlEncodedContent(parameters);
+        using var response = await _httpClient.PostAsync(OAuthTokenEndpoint, content, cancellationToken)
+            .ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            var tokenResponse = JsonSerializer.Deserialize<ElyByOAuthTokenResponse>(body, JsonOptions);
+            return tokenResponse ?? throw new ElyByAuthException("Ely.by returned an empty OAuth token response.");
+        }
+
+        var error = TryDeserializeOAuthError(body);
+        throw new ElyByAuthException(error?.ErrorDescription ?? error?.Error ?? $"Ely.by OAuth token request failed with status {(int)response.StatusCode}.");
+    }
+
+    private async Task<ElyByAuthSession> CreateOAuthSessionAsync(
+        ElyByOAuthTokenResponse response,
+        string? fallbackRefreshToken,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(response.AccessToken))
+            throw new ElyByAuthException("Ely.by returned an OAuth response without an access token.");
+
+        var accountInfo = await GetOAuthAccountInfoAsync(response.AccessToken, cancellationToken).ConfigureAwait(false);
+        var uuid = NormalizeUuid(accountInfo.UUID);
+        if (string.IsNullOrWhiteSpace(uuid))
+            throw new ElyByAuthException("Ely.by returned account info without a UUID.");
+
+        if (string.IsNullOrWhiteSpace(accountInfo.Username))
+            throw new ElyByAuthException("Ely.by returned account info without a username.");
+
+        var expiresAt = response.ExpiresIn > 0
+            ? DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn)
+            : (DateTimeOffset?)null;
+
+        return new ElyByAuthSession(
+            accountInfo.Username,
+            uuid,
+            response.AccessToken,
+            Guid.NewGuid().ToString("N"),
+            string.IsNullOrWhiteSpace(response.RefreshToken) ? fallbackRefreshToken : response.RefreshToken,
+            expiresAt,
+            ElyByAuthFlow.OAuth);
+    }
+
+    private async Task<ElyByAccountInfoResponse> GetOAuthAccountInfoAsync(
+        string accessToken,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, AccountInfoEndpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            var accountInfo = JsonSerializer.Deserialize<ElyByAccountInfoResponse>(body, JsonOptions);
+            return accountInfo ?? throw new ElyByAuthException("Ely.by returned an empty account info response.");
+        }
+
+        var error = TryDeserializeOAuthAccountError(body);
+        throw new ElyByAuthException(error?.Message ?? $"Ely.by account info request failed with status {(int)response.StatusCode}.");
     }
 
     private static ElyByAuthSession CreateSession(
@@ -178,6 +328,54 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
         => error?.ErrorMessage?.Contains("two factor", StringComparison.OrdinalIgnoreCase) == true
            || error?.ErrorMessage?.Contains("2fa", StringComparison.OrdinalIgnoreCase) == true;
 
+    private ElyByOAuthOptions GetConfiguredOAuthOptions()
+    {
+        if (_oauthOptions is { IsConfigured: true })
+            return _oauthOptions;
+
+        throw new ElyByAuthException("Ely.by OAuth is not configured. Set the Ely.by client id, client secret, and redirect URI in App.xaml.cs.");
+    }
+
+    private static string BuildQuery(IEnumerable<(string Key, string? Value)> parameters)
+        => string.Join(
+            "&",
+            parameters
+                .Where(parameter => !string.IsNullOrWhiteSpace(parameter.Value))
+                .Select(parameter => $"{Uri.EscapeDataString(parameter.Key)}={Uri.EscapeDataString(parameter.Value!)}"));
+
+    private static string NormalizeUuid(string? uuid)
+        => string.IsNullOrWhiteSpace(uuid) ? string.Empty : uuid.Replace("-", string.Empty, StringComparison.Ordinal);
+
+    private static ElyByOAuthErrorResponse? TryDeserializeOAuthError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<ElyByOAuthErrorResponse>(body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static ElyByOAuthAccountErrorResponse? TryDeserializeOAuthAccountError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<ElyByOAuthAccountErrorResponse>(body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
     private sealed record ElyByAuthenticateRequest(
         [property: JsonPropertyName("username")] string Username,
         [property: JsonPropertyName("password")] string Password,
@@ -205,4 +403,21 @@ internal sealed class ElyByAuthClient : IElyByAuthClient
     private sealed record ElyByErrorResponse(
         [property: JsonPropertyName("error")] string? Error,
         [property: JsonPropertyName("errorMessage")] string? ErrorMessage);
+
+    private sealed record ElyByOAuthTokenResponse(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+        [property: JsonPropertyName("token_type")] string? TokenType,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+
+    private sealed record ElyByOAuthErrorResponse(
+        [property: JsonPropertyName("error")] string? Error,
+        [property: JsonPropertyName("error_description")] string? ErrorDescription);
+
+    private sealed record ElyByAccountInfoResponse(
+        [property: JsonPropertyName("uuid")] string? UUID,
+        [property: JsonPropertyName("username")] string? Username);
+
+    private sealed record ElyByOAuthAccountErrorResponse(
+        [property: JsonPropertyName("message")] string? Message);
 }

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthClient.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthClient.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed class ElyByAuthClient : IElyByAuthClient
+{
+    private static readonly Uri BaseUri = new("https://authserver.ely.by/");
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly ILogger<ElyByAuthClient> _logger;
+    private readonly HttpClient _httpClient;
+
+    public ElyByAuthClient(ILogger<ElyByAuthClient> logger, HttpClient? httpClient = null)
+    {
+        _logger = logger;
+        _httpClient = httpClient ?? new HttpClient();
+        _httpClient.BaseAddress ??= BaseUri;
+    }
+
+    public async Task<ElyByAuthSession> AuthenticateAsync(
+        string login,
+        string password,
+        string? twoFactorCode = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(login);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        var clientToken = Guid.NewGuid().ToString("N");
+
+        try
+        {
+            return await AuthenticateCoreAsync(login, password, clientToken, cancellationToken).ConfigureAwait(false);
+        }
+        catch (ElyByTwoFactorRequiredException) when (!string.IsNullOrWhiteSpace(twoFactorCode))
+        {
+            return await AuthenticateCoreAsync(login, $"{password}:{twoFactorCode}", clientToken, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<bool> ValidateAsync(
+        string accessToken,
+        string clientToken,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+                "auth/validate",
+                new ElyByTokenRequest(accessToken, clientToken),
+                JsonOptions,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NoContent)
+            return true;
+
+        if (response.IsSuccessStatusCode)
+            return true;
+
+        _logger.LogDebug("Ely.by token validation failed with status {StatusCode}.", response.StatusCode);
+        return false;
+    }
+
+    public async Task<ElyByAuthSession> RefreshAsync(
+        ElyByStoredAccount account,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await SendAsync<ElyByTokenRequest, ElyByAuthResponse>(
+                "auth/refresh",
+                new ElyByTokenRequest(account.AccessToken, account.ClientToken),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return CreateSession(response, account.ClientToken, account.Name, account.UUID);
+    }
+
+    public async Task InvalidateAsync(
+        ElyByStoredAccount account,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+                "auth/invalidate",
+                new ElyByTokenRequest(account.AccessToken, account.ClientToken),
+                JsonOptions,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NoContent)
+        {
+            _logger.LogWarning(
+                "Ely.by token invalidation for {AccountName} returned {StatusCode}.",
+                account.Name,
+                response.StatusCode);
+        }
+    }
+
+    private async Task<ElyByAuthSession> AuthenticateCoreAsync(
+        string login,
+        string password,
+        string clientToken,
+        CancellationToken cancellationToken)
+    {
+        var response = await SendAsync<ElyByAuthenticateRequest, ElyByAuthResponse>(
+                "auth/authenticate",
+                new ElyByAuthenticateRequest(login, password, clientToken, true),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return CreateSession(response, clientToken, null, null);
+    }
+
+    private async Task<TResponse> SendAsync<TRequest, TResponse>(
+        string path,
+        TRequest request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.PostAsJsonAsync(path, request, JsonOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            var result = JsonSerializer.Deserialize<TResponse>(body, JsonOptions);
+            return result ?? throw new ElyByAuthException("Ely.by returned an empty authentication response.");
+        }
+
+        var error = TryDeserializeError(body);
+        if (IsTwoFactorRequired(error))
+            throw new ElyByTwoFactorRequiredException();
+
+        throw new ElyByAuthException(error?.ErrorMessage ?? error?.Error ?? $"Ely.by request failed with status {(int)response.StatusCode}.");
+    }
+
+    private static ElyByAuthSession CreateSession(
+        ElyByAuthResponse response,
+        string fallbackClientToken,
+        string? fallbackName,
+        string? fallbackUuid)
+    {
+        var name = response.SelectedProfile?.Name ?? fallbackName;
+        var uuid = response.SelectedProfile?.Id ?? fallbackUuid;
+
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ElyByAuthException("Ely.by returned an authentication response without a profile name.");
+
+        if (string.IsNullOrWhiteSpace(uuid))
+            throw new ElyByAuthException("Ely.by returned an authentication response without a profile id.");
+
+        if (string.IsNullOrWhiteSpace(response.AccessToken))
+            throw new ElyByAuthException("Ely.by returned an authentication response without an access token.");
+
+        return new ElyByAuthSession(
+            name,
+            uuid,
+            response.AccessToken,
+            string.IsNullOrWhiteSpace(response.ClientToken) ? fallbackClientToken : response.ClientToken);
+    }
+
+    private static ElyByErrorResponse? TryDeserializeError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<ElyByErrorResponse>(body, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsTwoFactorRequired(ElyByErrorResponse? error)
+        => error?.ErrorMessage?.Contains("two factor", StringComparison.OrdinalIgnoreCase) == true
+           || error?.ErrorMessage?.Contains("2fa", StringComparison.OrdinalIgnoreCase) == true;
+
+    private sealed record ElyByAuthenticateRequest(
+        [property: JsonPropertyName("username")] string Username,
+        [property: JsonPropertyName("password")] string Password,
+        [property: JsonPropertyName("clientToken")] string ClientToken,
+        [property: JsonPropertyName("requestUser")] bool RequestUser);
+
+    private sealed record ElyByTokenRequest(
+        [property: JsonPropertyName("accessToken")] string AccessToken,
+        [property: JsonPropertyName("clientToken")] string ClientToken);
+
+    private sealed record ElyByAuthResponse(
+        [property: JsonPropertyName("accessToken")] string? AccessToken,
+        [property: JsonPropertyName("clientToken")] string? ClientToken,
+        [property: JsonPropertyName("selectedProfile")] ElyByProfileResponse? SelectedProfile);
+
+    private sealed class ElyByProfileResponse
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+    }
+
+    private sealed record ElyByErrorResponse(
+        [property: JsonPropertyName("error")] string? Error,
+        [property: JsonPropertyName("errorMessage")] string? ErrorMessage);
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthException.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthException.cs
@@ -1,0 +1,22 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+public class ElyByAuthException : Exception
+{
+    public ElyByAuthException(string message)
+        : base(message)
+    {
+    }
+
+    public ElyByAuthException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+public sealed class ElyByTwoFactorRequiredException : ElyByAuthException
+{
+    public ElyByTwoFactorRequiredException()
+        : base("This Ely.by account requires a two-factor authentication code.")
+    {
+    }
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthFlow.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByAuthFlow.cs
@@ -1,0 +1,7 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal enum ElyByAuthFlow
+{
+    Direct,
+    OAuth
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByOAuthOptions.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByOAuthOptions.cs
@@ -1,0 +1,20 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed record ElyByOAuthOptions(
+    string ClientId,
+    string ClientSecret,
+    string RedirectUri,
+    string Scope = ElyByOAuthOptions.DefaultScope)
+{
+    public const string DefaultScope = "account_info offline_access minecraft_server_session";
+
+    public bool IsConfigured
+        => !IsPlaceholder(ClientId)
+           && !IsPlaceholder(ClientSecret)
+           && Uri.TryCreate(RedirectUri, UriKind.Absolute, out _);
+
+    private static bool IsPlaceholder(string? value)
+        => string.IsNullOrWhiteSpace(value)
+           || value.Contains("TODO", StringComparison.OrdinalIgnoreCase)
+           || value.Contains("YOUR_", StringComparison.OrdinalIgnoreCase);
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByStoredAccount.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByStoredAccount.cs
@@ -1,0 +1,11 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed class ElyByStoredAccount
+{
+    public string UniqueId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string UUID { get; set; } = string.Empty;
+    public string AccessToken { get; set; } = string.Empty;
+    public string ClientToken { get; set; } = string.Empty;
+    public DateTime LastUsed { get; set; } = DateTime.UtcNow;
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/ElyByStoredAccount.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/ElyByStoredAccount.cs
@@ -7,5 +7,8 @@ internal sealed class ElyByStoredAccount
     public string UUID { get; set; } = string.Empty;
     public string AccessToken { get; set; } = string.Empty;
     public string ClientToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTimeOffset? AccessTokenExpiresAt { get; set; }
+    public ElyByAuthFlow AuthFlow { get; set; } = ElyByAuthFlow.Direct;
     public DateTime LastUsed { get; set; } = DateTime.UtcNow;
 }

--- a/Emerald.CoreX/Services/Auth/ElyBy/IElyByAccountStore.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/IElyByAccountStore.cs
@@ -1,0 +1,9 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal interface IElyByAccountStore
+{
+    IReadOnlyList<ElyByStoredAccount> GetAccounts();
+    ElyByStoredAccount? Find(string uniqueId);
+    void Upsert(ElyByStoredAccount account);
+    void Remove(string uniqueId);
+}

--- a/Emerald.CoreX/Services/Auth/ElyBy/IElyByAuthClient.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/IElyByAuthClient.cs
@@ -1,0 +1,29 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal interface IElyByAuthClient
+{
+    Task<ElyByAuthSession> AuthenticateAsync(
+        string login,
+        string password,
+        string? twoFactorCode = null,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> ValidateAsync(
+        string accessToken,
+        string clientToken,
+        CancellationToken cancellationToken = default);
+
+    Task<ElyByAuthSession> RefreshAsync(
+        ElyByStoredAccount account,
+        CancellationToken cancellationToken = default);
+
+    Task InvalidateAsync(
+        ElyByStoredAccount account,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record ElyByAuthSession(
+    string Name,
+    string UUID,
+    string AccessToken,
+    string ClientToken);

--- a/Emerald.CoreX/Services/Auth/ElyBy/IElyByAuthClient.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/IElyByAuthClient.cs
@@ -2,6 +2,12 @@ namespace Emerald.CoreX.Services.Auth.ElyBy;
 
 internal interface IElyByAuthClient
 {
+    ElyByOAuthAuthorizationRequest CreateOAuthAuthorizationRequest(string state, string? loginHint = null);
+
+    Task<ElyByAuthSession> ExchangeOAuthCodeAsync(
+        string code,
+        CancellationToken cancellationToken = default);
+
     Task<ElyByAuthSession> AuthenticateAsync(
         string login,
         string password,
@@ -26,4 +32,7 @@ internal sealed record ElyByAuthSession(
     string Name,
     string UUID,
     string AccessToken,
-    string ClientToken);
+    string ClientToken,
+    string? RefreshToken = null,
+    DateTimeOffset? AccessTokenExpiresAt = null,
+    ElyByAuthFlow AuthFlow = ElyByAuthFlow.Direct);

--- a/Emerald.CoreX/Services/Auth/ElyBy/IElyByOAuthBrowser.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/IElyByOAuthBrowser.cs
@@ -1,0 +1,15 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal interface IElyByOAuthBrowser
+{
+    Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record ElyByOAuthAuthorizationRequest(
+    Uri AuthorizationUri,
+    Uri RedirectUri,
+    string State);
+
+internal sealed record ElyByOAuthAuthorizationResult(string Code);

--- a/Emerald.CoreX/Services/Auth/ElyBy/UnsupportedElyByOAuthBrowser.cs
+++ b/Emerald.CoreX/Services/Auth/ElyBy/UnsupportedElyByOAuthBrowser.cs
@@ -1,0 +1,9 @@
+namespace Emerald.CoreX.Services.Auth.ElyBy;
+
+internal sealed class UnsupportedElyByOAuthBrowser : IElyByOAuthBrowser
+{
+    public Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException("Ely.by browser authentication is not available in this environment.");
+}

--- a/Emerald.CoreX/Services/Auth/GameAuthenticationResult.cs
+++ b/Emerald.CoreX/Services/Auth/GameAuthenticationResult.cs
@@ -1,0 +1,13 @@
+using CmlLib.Core.Auth;
+
+namespace Emerald.CoreX.Services.Auth;
+
+public sealed record GameAuthenticationResult(
+    MSession Session,
+    AccountRuntimeAuthOptions RuntimeOptions)
+{
+    public GameAuthenticationResult(MSession session)
+        : this(session, AccountRuntimeAuthOptions.Empty)
+    {
+    }
+}

--- a/Emerald.CoreX/Services/Auth/IAccountAuthenticationProvider.cs
+++ b/Emerald.CoreX/Services/Auth/IAccountAuthenticationProvider.cs
@@ -1,0 +1,11 @@
+using Emerald.CoreX.Models;
+
+namespace Emerald.CoreX.Services.Auth;
+
+public interface IAccountAuthenticationProvider
+{
+    AccountType AccountType { get; }
+    string ProviderId { get; }
+    Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default);
+    Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default);
+}

--- a/Emerald.CoreX/Services/Auth/Microsoft/CmlLibMicrosoftAccountClient.cs
+++ b/Emerald.CoreX/Services/Auth/Microsoft/CmlLibMicrosoftAccountClient.cs
@@ -1,11 +1,12 @@
 using CmlLib.Core.Auth;
 using CmlLib.Core.Auth.Microsoft;
 using CmlLib.Core.Auth.Microsoft.Sessions;
+using Emerald.CoreX.Services;
 using Microsoft.Extensions.Logging;
 using XboxAuthNet.Game.Msal;
 using XboxAuthNet.Game.Msal.OAuth;
 
-namespace Emerald.CoreX.Services;
+namespace Emerald.CoreX.Services.Auth.Microsoft;
 
 internal sealed class CmlLibMicrosoftAccountClient(ILogger<AccountService> logger) : IMicrosoftAccountClient
 {

--- a/Emerald.CoreX/Services/Auth/Microsoft/CmlLibMicrosoftAccountClient.cs
+++ b/Emerald.CoreX/Services/Auth/Microsoft/CmlLibMicrosoftAccountClient.cs
@@ -56,11 +56,24 @@ internal sealed class CmlLibMicrosoftAccountClient(ILogger<AccountService> logge
             : null;
     }
 
-    public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync()
+    public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync(CancellationToken cancellationToken = default)
     {
         EnsureInitialized();
+        cancellationToken.ThrowIfCancellationRequested();
 
-        var session = await _loginHandler!.AuthenticateInteractively().ConfigureAwait(false);
+        var interactiveTask = _loginHandler!.AuthenticateInteractively();
+        MSession session;
+        try
+        {
+            session = await interactiveTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            ObserveInteractiveSignInAfterCancellation(interactiveTask);
+            throw;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
         SaveAccounts();
 
         return new MicrosoftInteractiveSignInResult(
@@ -112,6 +125,21 @@ internal sealed class CmlLibMicrosoftAccountClient(ILogger<AccountService> logge
     {
         if (_loginHandler is null)
             throw new InvalidOperationException("Microsoft account client was not initialized.");
+    }
+
+    private void ObserveInteractiveSignInAfterCancellation(Task<MSession> task)
+    {
+        _ = task.ContinueWith(
+            completedTask =>
+            {
+                if (completedTask.Exception is not null)
+                {
+                    _logger.LogDebug(
+                        completedTask.Exception,
+                        "A canceled Microsoft interactive sign-in completed with an error.");
+                }
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
     }
 
     private static string? Normalize(string? value)

--- a/Emerald.CoreX/Services/Auth/Microsoft/IMicrosoftAccountClient.cs
+++ b/Emerald.CoreX/Services/Auth/Microsoft/IMicrosoftAccountClient.cs
@@ -1,6 +1,6 @@
 using CmlLib.Core.Auth;
 
-namespace Emerald.CoreX.Services;
+namespace Emerald.CoreX.Services.Auth.Microsoft;
 
 internal interface IMicrosoftAccountClient
 {

--- a/Emerald.CoreX/Services/Auth/Microsoft/IMicrosoftAccountClient.cs
+++ b/Emerald.CoreX/Services/Auth/Microsoft/IMicrosoftAccountClient.cs
@@ -10,7 +10,7 @@ internal interface IMicrosoftAccountClient
 
     string? GetDefaultAccountIdentifier();
 
-    Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync();
+    Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync(CancellationToken cancellationToken = default);
 
     Task<MSession> AuthenticateAsync(string accountIdentifier);
 

--- a/Emerald.CoreX/Services/Auth/Microsoft/MicrosoftAccountAuthenticationProvider.cs
+++ b/Emerald.CoreX/Services/Auth/Microsoft/MicrosoftAccountAuthenticationProvider.cs
@@ -1,0 +1,19 @@
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+
+namespace Emerald.CoreX.Services.Auth.Microsoft;
+
+internal sealed class MicrosoftAccountAuthenticationProvider(IMicrosoftAccountClient microsoftAccountClient) : IAccountAuthenticationProvider
+{
+    public AccountType AccountType => AccountType.Microsoft;
+    public string ProviderId => AccountProviderIds.Microsoft;
+
+    public async Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default)
+    {
+        var session = await microsoftAccountClient.AuthenticateAsync(account.UniqueId).ConfigureAwait(false);
+        return new GameAuthenticationResult(session);
+    }
+
+    public Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default)
+        => microsoftAccountClient.SignOutAsync(account.UniqueId);
+}

--- a/Emerald.CoreX/Services/Auth/Offline/OfflineAccountAuthenticationProvider.cs
+++ b/Emerald.CoreX/Services/Auth/Offline/OfflineAccountAuthenticationProvider.cs
@@ -1,0 +1,17 @@
+using CmlLib.Core.Auth;
+using Emerald.CoreX.Models;
+using Emerald.CoreX.Services.Auth;
+
+namespace Emerald.CoreX.Services.Auth.Offline;
+
+internal sealed class OfflineAccountAuthenticationProvider : IAccountAuthenticationProvider
+{
+    public AccountType AccountType => AccountType.Offline;
+    public string ProviderId => AccountProviderIds.Offline;
+
+    public Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default)
+        => Task.FromResult(new GameAuthenticationResult(MSession.CreateOfflineSession(account.Name)));
+
+    public Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/Emerald.CoreX/Services/IAccountService.cs
+++ b/Emerald.CoreX/Services/IAccountService.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using CmlLib.Core.Auth;
+using Emerald.CoreX.Services.Auth;
 using Emerald.CoreX.Models;
 
 namespace Emerald.CoreX.Services;
@@ -13,11 +13,13 @@ public interface IAccountService
 {
     ObservableCollection<EAccount> Accounts { get; }
     bool RequireMicrosoftAccountForOfflineAccounts { get; }
+    bool RequireMicrosoftAccountForElyByAccounts { get; }
     Task LoadAllAccountsAsync();
     void CreateOfflineAccount(string username);
     Task SignInMicrosoftAccountAsync();
+    Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null);
     Task RemoveAccountAsync(EAccount account);
-    Task<MSession> AuthenticateAccountAsync(EAccount account);
+    Task<GameAuthenticationResult> AuthenticateAccountAsync(EAccount account);
     EAccount? GetMostRecentlyUsedAccount();
     EAccount? GetSelectedAccount();
     void SetSelectedAccount(EAccount? account);

--- a/Emerald.CoreX/Services/IAccountService.cs
+++ b/Emerald.CoreX/Services/IAccountService.cs
@@ -16,9 +16,13 @@ public interface IAccountService
     bool RequireMicrosoftAccountForElyByAccounts { get; }
     Task LoadAllAccountsAsync();
     void CreateOfflineAccount(string username);
-    Task SignInMicrosoftAccountAsync();
-    Task SignInElyByAccountAsync();
-    Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null);
+    Task SignInMicrosoftAccountAsync(CancellationToken cancellationToken = default);
+    Task SignInElyByAccountAsync(CancellationToken cancellationToken = default);
+    Task SignInElyByAccountAsync(
+        string login,
+        string password,
+        string? twoFactorCode = null,
+        CancellationToken cancellationToken = default);
     Task RemoveAccountAsync(EAccount account);
     Task<GameAuthenticationResult> AuthenticateAccountAsync(EAccount account);
     EAccount? GetMostRecentlyUsedAccount();

--- a/Emerald.CoreX/Services/IAccountService.cs
+++ b/Emerald.CoreX/Services/IAccountService.cs
@@ -17,6 +17,7 @@ public interface IAccountService
     Task LoadAllAccountsAsync();
     void CreateOfflineAccount(string username);
     Task SignInMicrosoftAccountAsync();
+    Task SignInElyByAccountAsync();
     Task SignInElyByAccountAsync(string login, string password, string? twoFactorCode = null);
     Task RemoveAccountAsync(EAccount account);
     Task<GameAuthenticationResult> AuthenticateAccountAsync(EAccount account);

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -160,7 +160,7 @@ public partial class App : Application
         });
         //ViewModels
         services.AddTransient<ViewModels.GamesPageViewModel>();
-        services.AddTransient<ViewModels.AccountsPageViewModel>();
+        services.AddSingleton<ViewModels.AccountsPageViewModel>();
         services.AddTransient<ViewModels.LogsPageViewModel>();
         services.AddTransient<ViewModels.ModrinthStorePageViewModel>();
     }

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -59,11 +59,8 @@ public partial class App : Application
 
     #region  Services
 
-    
-
     private void ConfigureAuthServices(IServiceCollection services)
     {
-        
         //Ely.By
         services.AddSingleton<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>(_ =>
             new CoreX.Services.Auth.ElyBy.ElyByOAuthOptions(
@@ -85,8 +82,7 @@ public partial class App : Application
                 provider.GetRequiredService<ILogger<Services.ElyByLoopbackOAuthBrowser>>(),
                 dispatcherQueue);
         });
-        
-        
+
         //authLib
         services.AddSingleton<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>(provider =>
             new CoreX.Services.Auth.Authlib.AuthlibInjectorService(
@@ -158,7 +154,6 @@ public partial class App : Application
 
     private void ConfigureSettingsServices(IServiceCollection services)
     {
-
         //Settings
         services.AddSingleton<Services.SettingsService>();
         services.AddSingleton<Services.IBaseSettingsService, Services.BaseSettingsService>(provider =>
@@ -172,7 +167,6 @@ public partial class App : Application
         services.AddSingleton<CoreX.Runtime.IGameRuntimeSettings, Services.GameRuntimeSettingsAdapter>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeProbe, CoreX.Services.ProcessJavaRuntimeProbe>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeCatalogService, CoreX.Services.JavaRuntimeCatalogService>();
-
     }
 
     private void ConfigureUiServices(IServiceCollection services)

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -8,6 +8,7 @@ using Emerald.CoreX.Runtime;
 using Emerald.CoreX.Store;
 using Emerald.CoreX.Store.Modrinth;
 using Emerald.Helpers;
+using Emerald.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Sinks.File;
@@ -56,32 +57,14 @@ public partial class App : Application
     public Window? MainWindow { get; private set; }
     protected IHost? Host { get; private set; }
 
-    /// <summary>
-    /// Registers the maintained services and viewmodels used by the active Uno shell.
-    /// </summary>
-    private void ConfigureServices(IServiceCollection services)
-    {
-        //Stores
-        services.AddTransient<ModStore>();
-        services.AddTransient<PluginStore>();
-        services.AddTransient<ResourcePackStore>();
-        services.AddTransient<ShaderStore>();
-        services.AddTransient<DataPackStore>();
-        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ModStore>());
-        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<PluginStore>());
-        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ResourcePackStore>());
-        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ShaderStore>());
-        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<DataPackStore>());
-        services.AddTransient<IGameStoreContentService, GameStoreContentService>();
+    #region  Services
 
-        //Settings
-        services.AddSingleton<Services.SettingsService>();
-        services.AddSingleton<Services.IBaseSettingsService, Services.BaseSettingsService>();
-        services.AddSingleton<Services.IAppUpdateService, Services.AppUpdateService>();
-        services.AddSingleton<CoreX.Services.IGlobalGameSettingsService, CoreX.Services.GlobalGameSettingsService>();
-        services.AddSingleton<CoreX.Runtime.IGameRuntimeSettings, Services.GameRuntimeSettingsAdapter>();
-        services.AddSingleton<CoreX.Services.IJavaRuntimeProbe, CoreX.Services.ProcessJavaRuntimeProbe>();
-        services.AddSingleton<CoreX.Services.IJavaRuntimeCatalogService, CoreX.Services.JavaRuntimeCatalogService>();
+    
+
+    private void ConfigureAuthServices(IServiceCollection services)
+    {
+        
+        //Ely.By
         services.AddSingleton<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>(_ =>
             new CoreX.Services.Auth.ElyBy.ElyByOAuthOptions(
                 ElyByClientId,
@@ -95,57 +78,27 @@ public partial class App : Application
         services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByOAuthBrowser>(provider =>
         {
             var dispatcherQueue = MainWindow?.DispatcherQueue
-                ?? DispatcherQueue.GetForCurrentThread()
-                ?? throw new InvalidOperationException("A DispatcherQueue is required for Ely.by browser authentication.");
+                                  ?? DispatcherQueue.GetForCurrentThread()
+                                  ?? throw new InvalidOperationException("A DispatcherQueue is required for Ely.by browser authentication.");
 
             return new Services.ElyByLoopbackOAuthBrowser(
                 provider.GetRequiredService<ILogger<Services.ElyByLoopbackOAuthBrowser>>(),
                 dispatcherQueue);
         });
+        
+        
+        //authLib
         services.AddSingleton<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>(provider =>
             new CoreX.Services.Auth.Authlib.AuthlibInjectorService(
                 provider.GetRequiredService<ILogger<CoreX.Services.Auth.Authlib.AuthlibInjectorService>>(),
                 Path.Combine(DirectResoucres.LocalDataPath, "authlib-injector")));
 
-        //Notifications
-        services.AddSingleton<CoreX.Notifications.INotificationService>(provider =>
-        {
-            var logger = provider.GetRequiredService<ILogger<CoreX.Notifications.NotificationService>>();
-            var inner = new CoreX.Notifications.NotificationService(logger);
-            return new DispatchedNotificationService(inner, MainWindow.DispatcherQueue);
-        });
-        services.AddTransient<ViewModels.NotificationListViewModel>();
-
-        //Mod Loaders
-        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Fabric>();
-        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Forge>();
-        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.LiteLoader>();
-        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Quilt>();
-        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Optifine>();
-
-        services.AddTransient<CoreX.Installers.ModLoaderRouter>();
-
-        services.AddSingleton<CoreX.Runtime.IGameRuntimeService>(provider =>
-        {
-            var logger = provider.GetRequiredService<ILogger<GameRuntimeService>>();
-            var notificationService = provider.GetRequiredService<CoreX.Notifications.INotificationService>();
-            var accountService = provider.GetRequiredService<CoreX.Services.IAccountService>();
-            var runtimeSettings = provider.GetRequiredService<CoreX.Runtime.IGameRuntimeSettings>();
-            var dispatcherQueue = MainWindow?.DispatcherQueue
-                ?? DispatcherQueue.GetForCurrentThread()
-                ?? throw new InvalidOperationException("A DispatcherQueue is required for the game runtime service.");
-
-            return new GameRuntimeService(logger, notificationService, accountService, runtimeSettings, dispatcherQueue);
-        });
-
-        //Core
-        services.AddSingleton<CoreX.Core>();
         //Accounts
         services.AddSingleton<CoreX.Services.IAccountService>(provider =>
         {
             var dispatcherQueue = MainWindow?.DispatcherQueue
-                ?? DispatcherQueue.GetForCurrentThread()
-                ?? throw new InvalidOperationException("A DispatcherQueue is required for the account service.");
+                                  ?? DispatcherQueue.GetForCurrentThread()
+                                  ?? throw new InvalidOperationException("A DispatcherQueue is required for the account service.");
 
             return new CoreX.Services.AccountService(
                 provider.GetRequiredService<ILogger<CoreX.Services.AccountService>>(),
@@ -158,11 +111,100 @@ public partial class App : Application
                 elyByOAuthBrowser: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByOAuthBrowser>(),
                 authlibInjectorService: provider.GetRequiredService<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>());
         });
+    }
+
+    private void ConfigureCoreServices(IServiceCollection services)
+    {
+        services.AddSingleton<CoreX.Core>();
+
+        services.AddSingleton<CoreX.Runtime.IGameRuntimeService>(provider =>
+        {
+            var logger = provider.GetRequiredService<ILogger<GameRuntimeService>>();
+            var notificationService = provider.GetRequiredService<CoreX.Notifications.INotificationService>();
+            var accountService = provider.GetRequiredService<CoreX.Services.IAccountService>();
+            var runtimeSettings = provider.GetRequiredService<CoreX.Runtime.IGameRuntimeSettings>();
+            var dispatcherQueue = MainWindow?.DispatcherQueue
+                                  ?? DispatcherQueue.GetForCurrentThread()
+                                  ?? throw new InvalidOperationException("A DispatcherQueue is required for the game runtime service.");
+
+            return new GameRuntimeService(logger, notificationService, accountService, runtimeSettings, dispatcherQueue);
+        });
+
+        //Mod Loaders
+        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Fabric>();
+        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Forge>();
+        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.LiteLoader>();
+        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Quilt>();
+        services.AddTransient<CoreX.Installers.IModLoaderInstaller, CoreX.Installers.Optifine>();
+
+        services.AddTransient<CoreX.Installers.ModLoaderRouter>();
+    }
+
+    private void ConfigureStoreServices(IServiceCollection services)
+    {
+        //Stores
+        services.AddTransient<ModStore>();
+        services.AddTransient<PluginStore>();
+        services.AddTransient<ResourcePackStore>();
+        services.AddTransient<ShaderStore>();
+        services.AddTransient<DataPackStore>();
+        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ModStore>());
+        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<PluginStore>());
+        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ResourcePackStore>());
+        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<ShaderStore>());
+        services.AddTransient<IModrinthStore>(provider => provider.GetRequiredService<DataPackStore>());
+        services.AddTransient<IGameStoreContentService, GameStoreContentService>();
+    }
+
+    private void ConfigureSettingsServices(IServiceCollection services)
+    {
+
+        //Settings
+        services.AddSingleton<Services.SettingsService>();
+        services.AddSingleton<Services.IBaseSettingsService, Services.BaseSettingsService>(provider =>
+        {
+            var logger = provider.GetRequiredService<ILogger<Services.BaseSettingsService>>();
+            var path = Path.Combine(DirectResoucres.LocalDataPath, "settings");
+            return new BaseSettingsService(logger, path);
+        });
+        services.AddSingleton<Services.IAppUpdateService, Services.AppUpdateService>();
+        services.AddSingleton<CoreX.Services.IGlobalGameSettingsService, CoreX.Services.GlobalGameSettingsService>();
+        services.AddSingleton<CoreX.Runtime.IGameRuntimeSettings, Services.GameRuntimeSettingsAdapter>();
+        services.AddSingleton<CoreX.Services.IJavaRuntimeProbe, CoreX.Services.ProcessJavaRuntimeProbe>();
+        services.AddSingleton<CoreX.Services.IJavaRuntimeCatalogService, CoreX.Services.JavaRuntimeCatalogService>();
+
+    }
+
+    private void ConfigureUiServices(IServiceCollection services)
+    {
+        //Notifications
+        services.AddSingleton<CoreX.Notifications.INotificationService>(provider =>
+        {
+            var logger = provider.GetRequiredService<ILogger<CoreX.Notifications.NotificationService>>();
+            var inner = new CoreX.Notifications.NotificationService(logger);
+            return new DispatchedNotificationService(inner, MainWindow.DispatcherQueue);
+        });
+
         //ViewModels
         services.AddTransient<ViewModels.GamesPageViewModel>();
+        services.AddTransient<ViewModels.NotificationListViewModel>();
         services.AddSingleton<ViewModels.AccountsPageViewModel>();
         services.AddTransient<ViewModels.LogsPageViewModel>();
         services.AddTransient<ViewModels.ModrinthStorePageViewModel>();
+    }
+    
+    #endregion
+    
+    /// <summary>
+    /// Registers the maintained services and viewmodels used by the active Uno shell.
+    /// </summary>
+    private void ConfigureServices(IServiceCollection services)
+    {
+        ConfigureCoreServices(services);
+        ConfigureSettingsServices(services);
+        ConfigureAuthServices(services);
+        ConfigureStoreServices(services);
+        ConfigureUiServices(services);
     }
 
     /// <summary>

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -21,6 +21,11 @@ namespace Emerald;
 /// </summary>
 public partial class App : Application
 {
+    private const string MicrosoftClientId = "dfeccda7-604a-4895-b409-9d35f1679b5d";
+    private const string ElyByClientId = "emerald1";
+    private const string ElyByClientSecret = "_hrxVlIoEWm1sqRlruFevD5v87mYW4EKPdmPWlraQoVP6kOXxJV9Y-qMrcm7Znk4";
+    private const string ElyByRedirectUri = "http://127.0.0.1:58135/oauth/elyby/";
+
     private Services.SettingsService SS;
 
     /// <summary>
@@ -77,9 +82,26 @@ public partial class App : Application
         services.AddSingleton<CoreX.Runtime.IGameRuntimeSettings, Services.GameRuntimeSettingsAdapter>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeProbe, CoreX.Services.ProcessJavaRuntimeProbe>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeCatalogService, CoreX.Services.JavaRuntimeCatalogService>();
+        services.AddSingleton<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>(_ =>
+            new CoreX.Services.Auth.ElyBy.ElyByOAuthOptions(
+                ElyByClientId,
+                ElyByClientSecret,
+                ElyByRedirectUri));
         services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByAuthClient>(provider =>
-            new CoreX.Services.Auth.ElyBy.ElyByAuthClient(provider.GetRequiredService<ILogger<CoreX.Services.Auth.ElyBy.ElyByAuthClient>>()));
+            new CoreX.Services.Auth.ElyBy.ElyByAuthClient(
+                provider.GetRequiredService<ILogger<CoreX.Services.Auth.ElyBy.ElyByAuthClient>>(),
+                provider.GetRequiredService<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>()));
         services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByAccountStore, CoreX.Services.Auth.ElyBy.ElyByAccountStore>();
+        services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByOAuthBrowser>(provider =>
+        {
+            var dispatcherQueue = MainWindow?.DispatcherQueue
+                ?? DispatcherQueue.GetForCurrentThread()
+                ?? throw new InvalidOperationException("A DispatcherQueue is required for Ely.by browser authentication.");
+
+            return new Services.ElyByLoopbackOAuthBrowser(
+                provider.GetRequiredService<ILogger<Services.ElyByLoopbackOAuthBrowser>>(),
+                dispatcherQueue);
+        });
         services.AddSingleton<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>(provider =>
             new CoreX.Services.Auth.Authlib.AuthlibInjectorService(
                 provider.GetRequiredService<ILogger<CoreX.Services.Auth.Authlib.AuthlibInjectorService>>(),
@@ -133,6 +155,7 @@ public partial class App : Application
                 notificationService: provider.GetRequiredService<CoreX.Notifications.INotificationService>(),
                 elyByAuthClient: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByAuthClient>(),
                 elyByAccountStore: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByAccountStore>(),
+                elyByOAuthBrowser: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByOAuthBrowser>(),
                 authlibInjectorService: provider.GetRequiredService<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>());
         });
         //ViewModels
@@ -180,7 +203,7 @@ public partial class App : Application
         this.Log().LogInformation("Application settings loaded.");
 
         var ac = Ioc.Default.GetService<CoreX.Services.IAccountService>();
-        _ = ac.InitializeAsync("dfeccda7-604a-4895-b409-9d35f1679b5d");
+        _ = ac.InitializeAsync(MicrosoftClientId);
         this.Log().LogInformation("Account service initialization requested.");
 
         // Do not repeat app initialization when the Window already has content,

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -77,6 +77,13 @@ public partial class App : Application
         services.AddSingleton<CoreX.Runtime.IGameRuntimeSettings, Services.GameRuntimeSettingsAdapter>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeProbe, CoreX.Services.ProcessJavaRuntimeProbe>();
         services.AddSingleton<CoreX.Services.IJavaRuntimeCatalogService, CoreX.Services.JavaRuntimeCatalogService>();
+        services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByAuthClient>(provider =>
+            new CoreX.Services.Auth.ElyBy.ElyByAuthClient(provider.GetRequiredService<ILogger<CoreX.Services.Auth.ElyBy.ElyByAuthClient>>()));
+        services.AddSingleton<CoreX.Services.Auth.ElyBy.IElyByAccountStore, CoreX.Services.Auth.ElyBy.ElyByAccountStore>();
+        services.AddSingleton<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>(provider =>
+            new CoreX.Services.Auth.Authlib.AuthlibInjectorService(
+                provider.GetRequiredService<ILogger<CoreX.Services.Auth.Authlib.AuthlibInjectorService>>(),
+                Path.Combine(DirectResoucres.LocalDataPath, "authlib-injector")));
 
         //Notifications
         services.AddSingleton<CoreX.Notifications.INotificationService>(provider =>
@@ -123,7 +130,10 @@ public partial class App : Application
                 provider.GetRequiredService<Services.IBaseSettingsService>(),
                 new Services.DispatcherQueueUiDispatcher(dispatcherQueue),
                 Path.Combine(DirectResoucres.LocalDataPath, "accounts", "cml_accounts.json"),
-                notificationService: provider.GetRequiredService<CoreX.Notifications.INotificationService>());
+                notificationService: provider.GetRequiredService<CoreX.Notifications.INotificationService>(),
+                elyByAuthClient: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByAuthClient>(),
+                elyByAccountStore: provider.GetRequiredService<CoreX.Services.Auth.ElyBy.IElyByAccountStore>(),
+                authlibInjectorService: provider.GetRequiredService<CoreX.Services.Auth.Authlib.IAuthlibInjectorService>());
         });
         //ViewModels
         services.AddTransient<ViewModels.GamesPageViewModel>();

--- a/Emerald/Services/ElyByLoopbackOAuthBrowser.cs
+++ b/Emerald/Services/ElyByLoopbackOAuthBrowser.cs
@@ -22,70 +22,13 @@ internal sealed class ElyByLoopbackOAuthBrowser(
     {
         EnsureLoopbackRedirectUri(request.RedirectUri);
 
-        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(AuthorizationTimeout);
-
-        using var listener = new HttpListener();
-        listener.Prefixes.Add(ToListenerPrefix(request.RedirectUri));
-        listener.Start();
-
-        var opened = await LaunchBrowserAsync(request.AuthorizationUri).ConfigureAwait(false);
-        if (!opened)
-            throw new ElyByAuthException("Could not open the Ely.by authorization page in your browser.");
+        using var timeoutSource = CreateAuthorizationTimeoutSource(cancellationToken);
+        using var listener = StartLoopbackListener(request.RedirectUri);
+        await EnsureBrowserOpenedAsync(request.AuthorizationUri).ConfigureAwait(false);
 
         try
         {
-            while (true)
-            {
-                var context = await listener.GetContextAsync().WaitAsync(timeoutSource.Token).ConfigureAwait(false);
-                if (!IsExpectedCallback(request.RedirectUri, context.Request.Url))
-                {
-                    await WriteHtmlResponseAsync(
-                        context.Response,
-                        404,
-                        "Not found",
-                        "This callback does not belong to the current Ely.by sign-in request.").ConfigureAwait(false);
-                    continue;
-                }
-
-                var query = context.Request.QueryString;
-                var state = query["state"];
-                if (!string.Equals(state, request.State, StringComparison.Ordinal))
-                {
-                    await WriteHtmlResponseAsync(
-                        context.Response,
-                        400,
-                        "Sign-in rejected",
-                        "The Ely.by sign-in response did not match the original request.").ConfigureAwait(false);
-                    throw new ElyByAuthException("Ely.by sign-in returned an invalid OAuth state.");
-                }
-
-                var error = query["error"];
-                if (!string.IsNullOrWhiteSpace(error))
-                {
-                    var message = query["error_message"] ?? query["error_description"] ?? error;
-                    await WriteHtmlResponseAsync(context.Response, 400, "Sign-in cancelled", message).ConfigureAwait(false);
-                    throw new ElyByAuthException(message);
-                }
-
-                var code = query["code"];
-                if (string.IsNullOrWhiteSpace(code))
-                {
-                    await WriteHtmlResponseAsync(
-                        context.Response,
-                        400,
-                        "Sign-in failed",
-                        "Ely.by did not return an authorization code.").ConfigureAwait(false);
-                    throw new ElyByAuthException("Ely.by did not return an authorization code.");
-                }
-
-                await WriteHtmlResponseAsync(
-                    context.Response,
-                    200,
-                    "Sign-in complete",
-                    "You can close this browser tab and return to Emerald.").ConfigureAwait(false);
-                return new ElyByOAuthAuthorizationResult(code);
-            }
+            return await WaitForAuthorizationResultAsync(listener, request, timeoutSource.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
@@ -99,6 +42,111 @@ internal sealed class ElyByLoopbackOAuthBrowser(
         {
             listener.Stop();
         }
+    }
+
+    private static CancellationTokenSource CreateAuthorizationTimeoutSource(CancellationToken cancellationToken)
+    {
+        var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(AuthorizationTimeout);
+        return timeoutSource;
+    }
+
+    private static HttpListener StartLoopbackListener(Uri redirectUri)
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add(ToListenerPrefix(redirectUri));
+        listener.Start();
+        return listener;
+    }
+
+    private async Task EnsureBrowserOpenedAsync(Uri authorizationUri)
+    {
+        var opened = await LaunchBrowserAsync(authorizationUri).ConfigureAwait(false);
+        if (!opened)
+            throw new ElyByAuthException("Could not open the Ely.by authorization page in your browser.");
+    }
+
+    private static async Task<ElyByOAuthAuthorizationResult> WaitForAuthorizationResultAsync(
+        HttpListener listener,
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var context = await listener.GetContextAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+            var result = await TryHandleCallbackAsync(request, context).ConfigureAwait(false);
+            if (result is not null)
+                return result;
+        }
+    }
+
+    private static async Task<ElyByOAuthAuthorizationResult?> TryHandleCallbackAsync(
+        ElyByOAuthAuthorizationRequest request,
+        HttpListenerContext context)
+    {
+        if (!IsExpectedCallback(request.RedirectUri, context.Request.Url))
+        {
+            await WriteHtmlResponseAsync(
+                context.Response,
+                404,
+                "Not found",
+                "This callback does not belong to the current Ely.by sign-in request.").ConfigureAwait(false);
+            return null;
+        }
+
+        await EnsureExpectedStateAsync(request, context).ConfigureAwait(false);
+        await EnsureNoOAuthErrorAsync(context).ConfigureAwait(false);
+        var code = await GetAuthorizationCodeAsync(context).ConfigureAwait(false);
+
+        await WriteHtmlResponseAsync(
+            context.Response,
+            200,
+            "Sign-in complete",
+            "You can close this browser tab and return to Emerald.").ConfigureAwait(false);
+
+        return new ElyByOAuthAuthorizationResult(code);
+    }
+
+    private static async Task EnsureExpectedStateAsync(
+        ElyByOAuthAuthorizationRequest request,
+        HttpListenerContext context)
+    {
+        var state = context.Request.QueryString["state"];
+        if (string.Equals(state, request.State, StringComparison.Ordinal))
+            return;
+
+        await WriteHtmlResponseAsync(
+            context.Response,
+            400,
+            "Sign-in rejected",
+            "The Ely.by sign-in response did not match the original request.").ConfigureAwait(false);
+        throw new ElyByAuthException("Ely.by sign-in returned an invalid OAuth state.");
+    }
+
+    private static async Task EnsureNoOAuthErrorAsync(HttpListenerContext context)
+    {
+        var query = context.Request.QueryString;
+        var error = query["error"];
+        if (string.IsNullOrWhiteSpace(error))
+            return;
+
+        var message = query["error_message"] ?? query["error_description"] ?? error;
+        await WriteHtmlResponseAsync(context.Response, 400, "Sign-in cancelled", message).ConfigureAwait(false);
+        throw new ElyByAuthException(message);
+    }
+
+    private static async Task<string> GetAuthorizationCodeAsync(HttpListenerContext context)
+    {
+        var code = context.Request.QueryString["code"];
+        if (!string.IsNullOrWhiteSpace(code))
+            return code;
+
+        await WriteHtmlResponseAsync(
+            context.Response,
+            400,
+            "Sign-in failed",
+            "Ely.by did not return an authorization code.").ConfigureAwait(false);
+        throw new ElyByAuthException("Ely.by did not return an authorization code.");
     }
 
     private Task<bool> LaunchBrowserAsync(Uri uri)

--- a/Emerald/Services/ElyByLoopbackOAuthBrowser.cs
+++ b/Emerald/Services/ElyByLoopbackOAuthBrowser.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Text;
+using Emerald.CoreX.Services.Auth.ElyBy;
+using Microsoft.Extensions.Logging;
+using Windows.System;
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
+
+namespace Emerald.Services;
+
+internal sealed class ElyByLoopbackOAuthBrowser(
+    ILogger<ElyByLoopbackOAuthBrowser> logger,
+    DispatcherQueue dispatcherQueue) : IElyByOAuthBrowser
+{
+    private static readonly TimeSpan AuthorizationTimeout = TimeSpan.FromMinutes(5);
+
+    private readonly ILogger<ElyByLoopbackOAuthBrowser> _logger = logger;
+    private readonly DispatcherQueue _dispatcherQueue = dispatcherQueue;
+
+    public async Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureLoopbackRedirectUri(request.RedirectUri);
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(AuthorizationTimeout);
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add(ToListenerPrefix(request.RedirectUri));
+        listener.Start();
+
+        var opened = await LaunchBrowserAsync(request.AuthorizationUri).ConfigureAwait(false);
+        if (!opened)
+            throw new ElyByAuthException("Could not open the Ely.by authorization page in your browser.");
+
+        try
+        {
+            while (true)
+            {
+                var context = await listener.GetContextAsync().WaitAsync(timeoutSource.Token).ConfigureAwait(false);
+                if (!IsExpectedCallback(request.RedirectUri, context.Request.Url))
+                {
+                    await WriteHtmlResponseAsync(
+                        context.Response,
+                        404,
+                        "Not found",
+                        "This callback does not belong to the current Ely.by sign-in request.").ConfigureAwait(false);
+                    continue;
+                }
+
+                var query = context.Request.QueryString;
+                var state = query["state"];
+                if (!string.Equals(state, request.State, StringComparison.Ordinal))
+                {
+                    await WriteHtmlResponseAsync(
+                        context.Response,
+                        400,
+                        "Sign-in rejected",
+                        "The Ely.by sign-in response did not match the original request.").ConfigureAwait(false);
+                    throw new ElyByAuthException("Ely.by sign-in returned an invalid OAuth state.");
+                }
+
+                var error = query["error"];
+                if (!string.IsNullOrWhiteSpace(error))
+                {
+                    var message = query["error_message"] ?? query["error_description"] ?? error;
+                    await WriteHtmlResponseAsync(context.Response, 400, "Sign-in cancelled", message).ConfigureAwait(false);
+                    throw new ElyByAuthException(message);
+                }
+
+                var code = query["code"];
+                if (string.IsNullOrWhiteSpace(code))
+                {
+                    await WriteHtmlResponseAsync(
+                        context.Response,
+                        400,
+                        "Sign-in failed",
+                        "Ely.by did not return an authorization code.").ConfigureAwait(false);
+                    throw new ElyByAuthException("Ely.by did not return an authorization code.");
+                }
+
+                await WriteHtmlResponseAsync(
+                    context.Response,
+                    200,
+                    "Sign-in complete",
+                    "You can close this browser tab and return to Emerald.").ConfigureAwait(false);
+                return new ElyByOAuthAuthorizationResult(code);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new ElyByAuthException("Timed out waiting for Ely.by browser sign-in to complete.");
+        }
+        catch (HttpListenerException ex) when (timeoutSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new ElyByAuthException("Timed out waiting for Ely.by browser sign-in to complete.", ex);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private Task<bool> LaunchBrowserAsync(Uri uri)
+    {
+        if (_dispatcherQueue.HasThreadAccess)
+            return Launcher.LaunchUriAsync(uri).AsTask();
+
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_dispatcherQueue.TryEnqueue(async () =>
+            {
+                try
+                {
+                    completion.SetResult(await Launcher.LaunchUriAsync(uri));
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            }))
+        {
+            completion.SetException(new InvalidOperationException("Failed to dispatch Ely.by browser launch to the UI thread."));
+        }
+
+        return completion.Task;
+    }
+
+    private static void EnsureLoopbackRedirectUri(Uri redirectUri)
+    {
+        if (!string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+            throw new ElyByAuthException("Ely.by OAuth redirect URI must use http for the local loopback callback.");
+
+        if (!IPAddress.TryParse(redirectUri.Host, out var address) || !IPAddress.IsLoopback(address))
+            throw new ElyByAuthException("Ely.by OAuth redirect URI must use a loopback host such as 127.0.0.1.");
+
+        if (redirectUri.Port <= 0)
+            throw new ElyByAuthException("Ely.by OAuth redirect URI must include a local callback port.");
+    }
+
+    private static string ToListenerPrefix(Uri redirectUri)
+    {
+        var prefix = redirectUri.GetLeftPart(UriPartial.Path);
+        return prefix.EndsWith("/", StringComparison.Ordinal) ? prefix : prefix + "/";
+    }
+
+    private static bool IsExpectedCallback(Uri expectedRedirectUri, Uri? actualUri)
+    {
+        if (actualUri is null)
+            return false;
+
+        return string.Equals(actualUri.Scheme, expectedRedirectUri.Scheme, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(actualUri.Host, expectedRedirectUri.Host, StringComparison.OrdinalIgnoreCase)
+               && actualUri.Port == expectedRedirectUri.Port
+               && string.Equals(
+                   NormalizePath(actualUri.AbsolutePath),
+                   NormalizePath(expectedRedirectUri.AbsolutePath),
+                   StringComparison.Ordinal);
+    }
+
+    private static string NormalizePath(string path)
+        => path.EndsWith("/", StringComparison.Ordinal) ? path : path + "/";
+
+    private static async Task WriteHtmlResponseAsync(
+        HttpListenerResponse response,
+        int statusCode,
+        string title,
+        string body)
+    {
+        response.StatusCode = statusCode;
+        response.ContentType = "text/html; charset=utf-8";
+        var html = $"""
+            <!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>{WebUtility.HtmlEncode(title)}</title>
+            </head>
+            <body style="font-family: system-ui, sans-serif; margin: 2rem;">
+              <h1>{WebUtility.HtmlEncode(title)}</h1>
+              <p>{WebUtility.HtmlEncode(body)}</p>
+            </body>
+            </html>
+            """;
+        var buffer = Encoding.UTF8.GetBytes(html);
+        response.ContentLength64 = buffer.Length;
+        await response.OutputStream.WriteAsync(buffer).ConfigureAwait(false);
+        response.Close();
+    }
+}

--- a/Emerald/Strings/en/Resources.resw
+++ b/Emerald/Strings/en/Resources.resw
@@ -730,6 +730,9 @@
   <data name="SignInWithElyBy" xml:space="preserve">
     <value>Sign in with Ely.by</value>
   </data>
+  <data name="CancelLogin" xml:space="preserve">
+    <value>Cancel login</value>
+  </data>
   <data name="Store" xml:space="preserve">
     <value>Store</value>
   </data>

--- a/Emerald/Strings/en/Resources.resw
+++ b/Emerald/Strings/en/Resources.resw
@@ -144,6 +144,24 @@
   <data name="Add" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="ElyByPasswordPlaceholder" xml:space="preserve">
+    <value>Enter your Ely.by password</value>
+  </data>
+  <data name="ElyByTwoFactorCode" xml:space="preserve">
+    <value>Two-factor code</value>
+  </data>
+  <data name="ElyByTwoFactorCodePlaceholder" xml:space="preserve">
+    <value>Optional</value>
+  </data>
+  <data name="ElyByUsernameOrEmail" xml:space="preserve">
+    <value>Ely.by username or email</value>
+  </data>
+  <data name="ElyByUsernameOrEmailPlaceholder" xml:space="preserve">
+    <value>Enter your Ely.by username or email</value>
+  </data>
+  <data name="EnterYourDesiredUsername" xml:space="preserve">
+    <value>Enter your desired username</value>
+  </data>
   <data name="AdvancedMinecraftSettings" xml:space="preserve">
     <value>Advanced Settings</value>
   </data>
@@ -164,6 +182,9 @@
   </data>
   <data name="AutoDownloadUpdates" xml:space="preserve">
     <value>Automatically download updates if available</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
   </data>
   <data name="OverrideMainSettingsForGame" xml:space="preserve">
     <value>Override main settings for this game</value>
@@ -612,6 +633,9 @@
   <data name="OfflineAccountNeedsMicrosoftDescription" xml:space="preserve">
     <value>Offline account creation is unavailable until at least one Microsoft account is added.</value>
   </data>
+  <data name="ElyByAccountNeedsMicrosoftDescription" xml:space="preserve">
+    <value>Ely.by sign-in is unavailable until at least one Microsoft account is added.</value>
+  </data>
   <data name="OfflineMode" xml:space="preserve">
     <value>Offline Mode</value>
   </data>
@@ -702,6 +726,9 @@
   </data>
   <data name="SignInWithMS" xml:space="preserve">
     <value>Sign-in with Microsoft</value>
+  </data>
+  <data name="SignInWithElyBy" xml:space="preserve">
+    <value>Sign in with Ely.by</value>
   </data>
   <data name="Store" xml:space="preserve">
     <value>Store</value>

--- a/Emerald/ViewModels/AccountsPageViewModel.cs
+++ b/Emerald/ViewModels/AccountsPageViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Emerald.CoreX.Models;
 using Emerald.CoreX.Notifications;
 using Emerald.CoreX.Services;
+using Emerald.CoreX.Services.Auth.ElyBy;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -27,14 +28,28 @@ public partial class AccountsPageViewModel : ObservableObject
     [ObservableProperty]
     private string _offlineUsername = string.Empty;
 
+    [ObservableProperty]
+    private string _elyByLogin = string.Empty;
+
+    [ObservableProperty]
+    private string _elyByPassword = string.Empty;
+
+    [ObservableProperty]
+    private string _elyByTwoFactorCode = string.Empty;
+
     public ObservableCollection<EAccount> Accounts => _accountService.Accounts;
     public bool HasLoadError => !string.IsNullOrWhiteSpace(LoadErrorMessage);
     public EAccount? SelectedAccount => _accountService.GetSelectedAccount();
     public bool CanCreateOfflineAccount
         => !_accountService.RequireMicrosoftAccountForOfflineAccounts
            || Accounts.Any(account => account.Type == AccountType.Microsoft);
+    public bool CanCreateElyByAccount
+        => !_accountService.RequireMicrosoftAccountForElyByAccounts
+           || Accounts.Any(account => account.Type == AccountType.Microsoft);
     public bool ShowOfflineAccountRestriction
         => _accountService.RequireMicrosoftAccountForOfflineAccounts && !CanCreateOfflineAccount;
+    public bool ShowElyByAccountRestriction
+        => _accountService.RequireMicrosoftAccountForElyByAccounts && !CanCreateElyByAccount;
 
     public AccountsPageViewModel(IAccountService accountService, INotificationService notificationService, ILogger<AccountsPageViewModel> logger)
     {
@@ -83,6 +98,56 @@ public partial class AccountsPageViewModel : ObservableObject
             _logger.LogError(ex, "Failed to sign in with Microsoft account.");
             LoadErrorMessage = "Failed to add Microsoft account.";
             _notificationService.Error("SignInError", "Failed to add Microsoft account.", ex: ex);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AddElyByAccountAsync()
+    {
+        if (!CanCreateElyByAccount)
+        {
+            _notificationService.Warning("ElyByNeedsMicrosoft", "Sign in with a Microsoft account before adding Ely.by accounts.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(ElyByLogin))
+        {
+            _notificationService.Warning("InvalidUsername", "Ely.by username or email cannot be empty.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(ElyByPassword))
+        {
+            _notificationService.Warning("InvalidPassword", "Ely.by password cannot be empty.");
+            return;
+        }
+
+        IsLoading = true;
+        LoadErrorMessage = null;
+        try
+        {
+            await _accountService.SignInElyByAccountAsync(ElyByLogin, ElyByPassword, ElyByTwoFactorCode);
+            _notificationService.Info("AccountAdded", "Ely.by account added successfully!");
+            ElyByLogin = string.Empty;
+            ElyByPassword = string.Empty;
+            ElyByTwoFactorCode = string.Empty;
+            NotifyAccountStateChanged();
+        }
+        catch (ElyByTwoFactorRequiredException ex)
+        {
+            _logger.LogWarning(ex, "Ely.by sign-in requires two-factor authentication.");
+            LoadErrorMessage = "Enter the Ely.by two-factor code and try again.";
+            _notificationService.Warning("TwoFactorRequired", "Enter the Ely.by two-factor code and try again.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sign in with Ely.by account.");
+            LoadErrorMessage = "Failed to add Ely.by account.";
+            _notificationService.Error("ElyBySignInError", "Failed to add Ely.by account.", ex: ex);
         }
         finally
         {
@@ -171,6 +236,8 @@ public partial class AccountsPageViewModel : ObservableObject
     {
         OnPropertyChanged(nameof(SelectedAccount));
         OnPropertyChanged(nameof(CanCreateOfflineAccount));
+        OnPropertyChanged(nameof(CanCreateElyByAccount));
         OnPropertyChanged(nameof(ShowOfflineAccountRestriction));
+        OnPropertyChanged(nameof(ShowElyByAccountRestriction));
     }
 }

--- a/Emerald/ViewModels/AccountsPageViewModel.cs
+++ b/Emerald/ViewModels/AccountsPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -16,9 +17,27 @@ public partial class AccountsPageViewModel : ObservableObject
     private readonly IAccountService _accountService;
     private readonly INotificationService _notificationService;
     private readonly ILogger<AccountsPageViewModel> _logger;
+    private CancellationTokenSource? _loginCancellationSource;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LoadingMessage))]
     private bool _isLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LoadingMessage))]
+    [NotifyPropertyChangedFor(nameof(CanStartMicrosoftLogin))]
+    [NotifyPropertyChangedFor(nameof(CanStartElyByLogin))]
+    [NotifyPropertyChangedFor(nameof(CanStartOfflineAccount))]
+    [NotifyPropertyChangedFor(nameof(CanCancelLogin))]
+    [NotifyCanExecuteChangedFor(nameof(AddMicrosoftAccountCommand))]
+    [NotifyCanExecuteChangedFor(nameof(AddElyByAccountCommand))]
+    [NotifyCanExecuteChangedFor(nameof(AddOfflineAccountCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelLoginCommand))]
+    private bool _isLoginInProgress;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LoadingMessage))]
+    private string _loginStatusMessage = "Loading accounts...";
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasLoadError))]
@@ -36,6 +55,12 @@ public partial class AccountsPageViewModel : ObservableObject
     public bool CanCreateElyByAccount
         => !_accountService.RequireMicrosoftAccountForElyByAccounts
            || Accounts.Any(account => account.Type == AccountType.Microsoft);
+    public bool CanStartMicrosoftLogin => !IsLoginInProgress;
+    public bool CanStartElyByLogin => CanCreateElyByAccount && !IsLoginInProgress;
+    public bool CanStartOfflineAccount => CanCreateOfflineAccount && !IsLoginInProgress;
+    public bool CanCancelLogin
+        => IsLoginInProgress && _loginCancellationSource is { IsCancellationRequested: false };
+    public string LoadingMessage => IsLoginInProgress ? LoginStatusMessage : "Loading accounts...";
     public bool ShowOfflineAccountRestriction
         => _accountService.RequireMicrosoftAccountForOfflineAccounts && !CanCreateOfflineAccount;
     public bool ShowElyByAccountRestriction
@@ -51,6 +76,12 @@ public partial class AccountsPageViewModel : ObservableObject
     [RelayCommand]
     private async Task InitializeAsync()
     {
+        if (IsLoginInProgress)
+        {
+            NotifyAccountStateChanged();
+            return;
+        }
+
         if (Accounts.Count > 0 && !HasLoadError) return;
 
         IsLoading = true;
@@ -72,16 +103,21 @@ public partial class AccountsPageViewModel : ObservableObject
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanStartMicrosoftLogin))]
     private async Task AddMicrosoftAccountAsync()
     {
-        IsLoading = true;
-        LoadErrorMessage = null;
+        var cancellationToken = BeginLogin("Complete Microsoft sign-in in your browser.");
         try
         {
-            await _accountService.SignInMicrosoftAccountAsync();
+            await _accountService.SignInMicrosoftAccountAsync(cancellationToken);
             _notificationService.Info("AccountAdded", "Microsoft account added successfully!");
             NotifyAccountStateChanged();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Microsoft sign-in was canceled.");
+            LoadErrorMessage = null;
+            _notificationService.Info("SignInCanceled", "Microsoft sign-in canceled.");
         }
         catch (Exception ex)
         {
@@ -91,11 +127,11 @@ public partial class AccountsPageViewModel : ObservableObject
         }
         finally
         {
-            IsLoading = false;
+            EndLogin(cancellationToken);
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanStartElyByLogin))]
     private async Task AddElyByAccountAsync()
     {
         if (!CanCreateElyByAccount)
@@ -104,14 +140,19 @@ public partial class AccountsPageViewModel : ObservableObject
             return;
         }
 
-        IsLoading = true;
-        LoadErrorMessage = null;
+        var cancellationToken = BeginLogin("Complete Ely.by sign-in in your browser.");
         try
         {
             _notificationService.Info("UsingBrowser", "Complete Ely.by sign-in in your browser.");
-            await _accountService.SignInElyByAccountAsync();
+            await _accountService.SignInElyByAccountAsync(cancellationToken);
             _notificationService.Info("AccountAdded", "Ely.by account added successfully!");
             NotifyAccountStateChanged();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Ely.by sign-in was canceled.");
+            LoadErrorMessage = null;
+            _notificationService.Info("SignInCanceled", "Ely.by sign-in canceled.");
         }
         catch (Exception ex)
         {
@@ -121,13 +162,18 @@ public partial class AccountsPageViewModel : ObservableObject
         }
         finally
         {
-            IsLoading = false;
+            EndLogin(cancellationToken);
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanStartOfflineAccount))]
     private void AddOfflineAccount()
     {
+        if (!CanStartOfflineAccount)
+        {
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(OfflineUsername))
         {
             _notificationService.Warning("InvalidUsername", "Offline username cannot be empty.");
@@ -147,6 +193,19 @@ public partial class AccountsPageViewModel : ObservableObject
             _logger.LogError(ex, "Failed to create offline account.");
             _notificationService.Error("CreateOfflineError", "Could not create offline account.", ex: ex);
         }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCancelLogin))]
+    private void CancelLogin()
+    {
+        if (_loginCancellationSource is not { IsCancellationRequested: false })
+        {
+            return;
+        }
+
+        LoginStatusMessage = "Canceling sign-in...";
+        _loginCancellationSource.Cancel();
+        NotifyLoginCommandStateChanged();
     }
 
     [RelayCommand]
@@ -202,12 +261,54 @@ public partial class AccountsPageViewModel : ObservableObject
         }
     }
 
+    private CancellationToken BeginLogin(string statusMessage)
+    {
+        _loginCancellationSource?.Dispose();
+        _loginCancellationSource = new CancellationTokenSource();
+        LoginStatusMessage = statusMessage;
+        LoadErrorMessage = null;
+        IsLoginInProgress = true;
+        IsLoading = true;
+        NotifyAccountStateChanged();
+        NotifyLoginCommandStateChanged();
+        return _loginCancellationSource.Token;
+    }
+
+    private void EndLogin(CancellationToken cancellationToken)
+    {
+        if (_loginCancellationSource is null || !_loginCancellationSource.Token.Equals(cancellationToken))
+        {
+            return;
+        }
+
+        _loginCancellationSource.Dispose();
+        _loginCancellationSource = null;
+        IsLoginInProgress = false;
+        LoginStatusMessage = "Loading accounts...";
+        IsLoading = false;
+        NotifyAccountStateChanged();
+        NotifyLoginCommandStateChanged();
+    }
+
     private void NotifyAccountStateChanged()
     {
         OnPropertyChanged(nameof(SelectedAccount));
         OnPropertyChanged(nameof(CanCreateOfflineAccount));
         OnPropertyChanged(nameof(CanCreateElyByAccount));
+        OnPropertyChanged(nameof(CanStartMicrosoftLogin));
+        OnPropertyChanged(nameof(CanStartElyByLogin));
+        OnPropertyChanged(nameof(CanStartOfflineAccount));
+        OnPropertyChanged(nameof(CanCancelLogin));
         OnPropertyChanged(nameof(ShowOfflineAccountRestriction));
         OnPropertyChanged(nameof(ShowElyByAccountRestriction));
+        NotifyLoginCommandStateChanged();
+    }
+
+    private void NotifyLoginCommandStateChanged()
+    {
+        AddMicrosoftAccountCommand.NotifyCanExecuteChanged();
+        AddElyByAccountCommand.NotifyCanExecuteChanged();
+        AddOfflineAccountCommand.NotifyCanExecuteChanged();
+        CancelLoginCommand.NotifyCanExecuteChanged();
     }
 }

--- a/Emerald/ViewModels/AccountsPageViewModel.cs
+++ b/Emerald/ViewModels/AccountsPageViewModel.cs
@@ -6,7 +6,6 @@ using CommunityToolkit.Mvvm.Input;
 using Emerald.CoreX.Models;
 using Emerald.CoreX.Notifications;
 using Emerald.CoreX.Services;
-using Emerald.CoreX.Services.Auth.ElyBy;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -27,15 +26,6 @@ public partial class AccountsPageViewModel : ObservableObject
 
     [ObservableProperty]
     private string _offlineUsername = string.Empty;
-
-    [ObservableProperty]
-    private string _elyByLogin = string.Empty;
-
-    [ObservableProperty]
-    private string _elyByPassword = string.Empty;
-
-    [ObservableProperty]
-    private string _elyByTwoFactorCode = string.Empty;
 
     public ObservableCollection<EAccount> Accounts => _accountService.Accounts;
     public bool HasLoadError => !string.IsNullOrWhiteSpace(LoadErrorMessage);
@@ -114,34 +104,14 @@ public partial class AccountsPageViewModel : ObservableObject
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(ElyByLogin))
-        {
-            _notificationService.Warning("InvalidUsername", "Ely.by username or email cannot be empty.");
-            return;
-        }
-
-        if (string.IsNullOrWhiteSpace(ElyByPassword))
-        {
-            _notificationService.Warning("InvalidPassword", "Ely.by password cannot be empty.");
-            return;
-        }
-
         IsLoading = true;
         LoadErrorMessage = null;
         try
         {
-            await _accountService.SignInElyByAccountAsync(ElyByLogin, ElyByPassword, ElyByTwoFactorCode);
+            _notificationService.Info("UsingBrowser", "Complete Ely.by sign-in in your browser.");
+            await _accountService.SignInElyByAccountAsync();
             _notificationService.Info("AccountAdded", "Ely.by account added successfully!");
-            ElyByLogin = string.Empty;
-            ElyByPassword = string.Empty;
-            ElyByTwoFactorCode = string.Empty;
             NotifyAccountStateChanged();
-        }
-        catch (ElyByTwoFactorRequiredException ex)
-        {
-            _logger.LogWarning(ex, "Ely.by sign-in requires two-factor authentication.");
-            LoadErrorMessage = "Enter the Ely.by two-factor code and try again.";
-            _notificationService.Warning("TwoFactorRequired", "Enter the Ely.by two-factor code and try again.");
         }
         catch (Exception ex)
         {

--- a/Emerald/Views/AccountsPage.xaml
+++ b/Emerald/Views/AccountsPage.xaml
@@ -28,7 +28,7 @@
           <StackPanel Spacing="4">
             <TextBlock Text="{x:Bind Name}" Style="{StaticResource BodyStrongTextBlockStyle}"/>
             <StackPanel Orientation="Horizontal" Spacing="8">
-              <TextBlock Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}" Text="{x:Bind Type}"/>
+              <TextBlock Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}" Text="{x:Bind ProviderDisplayName}"/>
             </StackPanel>
             <TextBlock Opacity="0.7" Style="{StaticResource CaptionTextBlockStyle}">
               <Run Text="Last used:"/>
@@ -77,17 +77,28 @@
           <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
           <CommandBar Background="Transparent" DefaultLabelPosition="Right">
             <AppBarButton Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}" Icon="Contact" Label="{helpers:Localize KeyName=SignInWithMS}"/>
+            <AppBarButton Click="AddElyByAccount_Click" Icon="World" Label="{helpers:Localize KeyName=SignInWithElyBy}" IsEnabled="{x:Bind ViewModel.CanCreateElyByAccount, Mode=OneWay}"/>
             <AppBarButton Click="AddOfflineAccount_Click" Icon="AddFriend" Label="{helpers:Localize KeyName=OfflineAccount}" IsEnabled="{x:Bind ViewModel.CanCreateOfflineAccount, Mode=OneWay}"/>
           </CommandBar>
         </StackPanel>
-        <TextBlock
-          HorizontalAlignment="Right"
-          MaxWidth="420"
-          Opacity="0.85"
-          Style="{StaticResource CaptionTextBlockStyle}"
-          Text="{helpers:Localize KeyName=OfflineAccountNeedsMicrosoftDescription}"
-          TextWrapping="WrapWholeWords"
-          Visibility="{x:Bind ViewModel.ShowOfflineAccountRestriction, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
+        <StackPanel Spacing="4" HorizontalAlignment="Right">
+          <TextBlock
+            HorizontalAlignment="Right"
+            MaxWidth="420"
+            Opacity="0.85"
+            Style="{StaticResource CaptionTextBlockStyle}"
+            Text="{helpers:Localize KeyName=ElyByAccountNeedsMicrosoftDescription}"
+            TextWrapping="WrapWholeWords"
+            Visibility="{x:Bind ViewModel.ShowElyByAccountRestriction, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
+          <TextBlock
+            HorizontalAlignment="Right"
+            MaxWidth="420"
+            Opacity="0.85"
+            Style="{StaticResource CaptionTextBlockStyle}"
+            Text="{helpers:Localize KeyName=OfflineAccountNeedsMicrosoftDescription}"
+            TextWrapping="WrapWholeWords"
+            Visibility="{x:Bind ViewModel.ShowOfflineAccountRestriction, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
+        </StackPanel>
       </StackPanel>
     </Grid>
 

--- a/Emerald/Views/AccountsPage.xaml
+++ b/Emerald/Views/AccountsPage.xaml
@@ -74,11 +74,15 @@
 
       <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
         <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
-          <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
           <CommandBar Background="Transparent" DefaultLabelPosition="Right">
-            <AppBarButton Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}" Icon="Contact" Label="{helpers:Localize KeyName=SignInWithMS}"/>
-            <AppBarButton Command="{x:Bind ViewModel.AddElyByAccountCommand}" Icon="World" Label="{helpers:Localize KeyName=SignInWithElyBy}" IsEnabled="{x:Bind ViewModel.CanCreateElyByAccount, Mode=OneWay}"/>
-            <AppBarButton Click="AddOfflineAccount_Click" Icon="AddFriend" Label="{helpers:Localize KeyName=OfflineAccount}" IsEnabled="{x:Bind ViewModel.CanCreateOfflineAccount, Mode=OneWay}"/>
+            <AppBarButton Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}" Icon="Contact" Label="{helpers:Localize KeyName=SignInWithMS}" IsEnabled="{x:Bind ViewModel.CanStartMicrosoftLogin, Mode=OneWay}"/>
+            <AppBarButton Command="{x:Bind ViewModel.AddElyByAccountCommand}" Icon="World" Label="{helpers:Localize KeyName=SignInWithElyBy}" IsEnabled="{x:Bind ViewModel.CanStartElyByLogin, Mode=OneWay}"/>
+            <AppBarButton Click="AddOfflineAccount_Click" Icon="AddFriend" Label="{helpers:Localize KeyName=OfflineAccount}" IsEnabled="{x:Bind ViewModel.CanStartOfflineAccount, Mode=OneWay}"/>
+            <AppBarButton
+              Command="{x:Bind ViewModel.CancelLoginCommand}"
+              Icon="Cancel"
+              Label="{helpers:Localize KeyName=CancelLogin}"
+              Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
           </CommandBar>
         </StackPanel>
         <StackPanel Spacing="4" HorizontalAlignment="Right">
@@ -121,7 +125,12 @@
 
         <StackPanel Spacing="12" HorizontalAlignment="Center" Margin="0,48,0,0" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}">
           <ProgressRing IsActive="True"/>
-          <TextBlock Text="Loading accounts..."/>
+          <TextBlock Text="{x:Bind ViewModel.LoadingMessage, Mode=OneWay}" TextAlignment="Center"/>
+          <Button
+            HorizontalAlignment="Center"
+            Command="{x:Bind ViewModel.CancelLoginCommand}"
+            Content="{helpers:Localize KeyName=CancelLogin}"
+            Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
         </StackPanel>
 
         <ItemsRepeater

--- a/Emerald/Views/AccountsPage.xaml
+++ b/Emerald/Views/AccountsPage.xaml
@@ -77,7 +77,7 @@
           <ProgressRing IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
           <CommandBar Background="Transparent" DefaultLabelPosition="Right">
             <AppBarButton Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}" Icon="Contact" Label="{helpers:Localize KeyName=SignInWithMS}"/>
-            <AppBarButton Click="AddElyByAccount_Click" Icon="World" Label="{helpers:Localize KeyName=SignInWithElyBy}" IsEnabled="{x:Bind ViewModel.CanCreateElyByAccount, Mode=OneWay}"/>
+            <AppBarButton Command="{x:Bind ViewModel.AddElyByAccountCommand}" Icon="World" Label="{helpers:Localize KeyName=SignInWithElyBy}" IsEnabled="{x:Bind ViewModel.CanCreateElyByAccount, Mode=OneWay}"/>
             <AppBarButton Click="AddOfflineAccount_Click" Icon="AddFriend" Label="{helpers:Localize KeyName=OfflineAccount}" IsEnabled="{x:Bind ViewModel.CanCreateOfflineAccount, Mode=OneWay}"/>
           </CommandBar>
         </StackPanel>

--- a/Emerald/Views/AccountsPage.xaml.cs
+++ b/Emerald/Views/AccountsPage.xaml.cs
@@ -35,7 +35,7 @@ public sealed partial class AccountsPage : Page
 
     private async void AddOfflineAccount_Click(object sender, RoutedEventArgs e)
     {
-        if (!ViewModel.CanCreateOfflineAccount)
+        if (!ViewModel.CanStartOfflineAccount)
         {
             return;
         }

--- a/Emerald/Views/AccountsPage.xaml.cs
+++ b/Emerald/Views/AccountsPage.xaml.cs
@@ -13,7 +13,11 @@ namespace Emerald.Views;
 public sealed partial class AccountsPage : Page
 {
     public AccountsPageViewModel ViewModel { get; }
-    private TextBox OfflineUserNameTextBox;
+    private TextBox OfflineUserNameTextBox = null!;
+    private TextBox ElyByLoginTextBox = null!;
+    private PasswordBox ElyByPasswordBox = null!;
+    private TextBox ElyByTwoFactorTextBox = null!;
+
     public AccountsPage()
     {
         ViewModel = Ioc.Default.GetService<AccountsPageViewModel>();
@@ -28,6 +32,7 @@ public sealed partial class AccountsPage : Page
             Header = "Username".Localize(),
             PlaceholderText = "EnterYourDesiredUsername".Localize()
         };
+
         await ViewModel.InitializeCommand.ExecuteAsync(null);
     }
 
@@ -49,10 +54,62 @@ public sealed partial class AccountsPage : Page
         dia.PrimaryButtonClick -= AddOfflineAccountDialog_PrimaryButtonClick;
     }
 
+    private async void AddElyByAccount_Click(object sender, RoutedEventArgs e)
+    {
+        ElyByLoginTextBox = new TextBox
+        {
+            Header = "ElyByUsernameOrEmail".Localize(),
+            PlaceholderText = "ElyByUsernameOrEmailPlaceholder".Localize()
+        };
+
+        ElyByPasswordBox = new PasswordBox
+        {
+            Header = "Password".Localize(),
+            PlaceholderText = "ElyByPasswordPlaceholder".Localize()
+        };
+
+        ElyByTwoFactorTextBox = new TextBox
+        {
+            Header = "ElyByTwoFactorCode".Localize(),
+            PlaceholderText = "ElyByTwoFactorCodePlaceholder".Localize()
+        };
+
+        var content = new StackPanel
+        {
+            Spacing = 12,
+            Children =
+            {
+                ElyByLoginTextBox,
+                ElyByPasswordBox,
+                ElyByTwoFactorTextBox
+            }
+        };
+
+        var dialog = content.ToContentDialog(
+            "SignInWithElyBy".Localize(),
+            PrimaryButtonText: "Login".Localize(),
+            closebtnText: "Cancel".Localize(),
+            defaultButton: ContentDialogButton.Primary);
+
+        dialog.PrimaryButtonClick += AddElyByAccountDialog_PrimaryButtonClick;
+
+        await dialog.ShowAsync();
+
+        dialog.PrimaryButtonClick -= AddElyByAccountDialog_PrimaryButtonClick;
+    }
+
     private void AddOfflineAccountDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
         ViewModel.OfflineUsername = OfflineUserNameTextBox.Text.Trim();
         ViewModel.AddOfflineAccountCommand.Execute(null);
+    }
+
+    private void AddElyByAccountDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        ViewModel.ElyByLogin = ElyByLoginTextBox.Text.Trim();
+        ViewModel.ElyByPassword = ElyByPasswordBox.Password;
+        ViewModel.ElyByTwoFactorCode = ElyByTwoFactorTextBox.Text.Trim();
+        ViewModel.AddElyByAccountCommand.Execute(null);
     }
 
     private async void RemoveAccount_Click(object sender, RoutedEventArgs e)

--- a/Emerald/Views/AccountsPage.xaml.cs
+++ b/Emerald/Views/AccountsPage.xaml.cs
@@ -14,9 +14,6 @@ public sealed partial class AccountsPage : Page
 {
     public AccountsPageViewModel ViewModel { get; }
     private TextBox OfflineUserNameTextBox = null!;
-    private TextBox ElyByLoginTextBox = null!;
-    private PasswordBox ElyByPasswordBox = null!;
-    private TextBox ElyByTwoFactorTextBox = null!;
 
     public AccountsPage()
     {
@@ -54,62 +51,10 @@ public sealed partial class AccountsPage : Page
         dia.PrimaryButtonClick -= AddOfflineAccountDialog_PrimaryButtonClick;
     }
 
-    private async void AddElyByAccount_Click(object sender, RoutedEventArgs e)
-    {
-        ElyByLoginTextBox = new TextBox
-        {
-            Header = "ElyByUsernameOrEmail".Localize(),
-            PlaceholderText = "ElyByUsernameOrEmailPlaceholder".Localize()
-        };
-
-        ElyByPasswordBox = new PasswordBox
-        {
-            Header = "Password".Localize(),
-            PlaceholderText = "ElyByPasswordPlaceholder".Localize()
-        };
-
-        ElyByTwoFactorTextBox = new TextBox
-        {
-            Header = "ElyByTwoFactorCode".Localize(),
-            PlaceholderText = "ElyByTwoFactorCodePlaceholder".Localize()
-        };
-
-        var content = new StackPanel
-        {
-            Spacing = 12,
-            Children =
-            {
-                ElyByLoginTextBox,
-                ElyByPasswordBox,
-                ElyByTwoFactorTextBox
-            }
-        };
-
-        var dialog = content.ToContentDialog(
-            "SignInWithElyBy".Localize(),
-            PrimaryButtonText: "Login".Localize(),
-            closebtnText: "Cancel".Localize(),
-            defaultButton: ContentDialogButton.Primary);
-
-        dialog.PrimaryButtonClick += AddElyByAccountDialog_PrimaryButtonClick;
-
-        await dialog.ShowAsync();
-
-        dialog.PrimaryButtonClick -= AddElyByAccountDialog_PrimaryButtonClick;
-    }
-
     private void AddOfflineAccountDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
         ViewModel.OfflineUsername = OfflineUserNameTextBox.Text.Trim();
         ViewModel.AddOfflineAccountCommand.Execute(null);
-    }
-
-    private void AddElyByAccountDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-    {
-        ViewModel.ElyByLogin = ElyByLoginTextBox.Text.Trim();
-        ViewModel.ElyByPassword = ElyByPasswordBox.Password;
-        ViewModel.ElyByTwoFactorCode = ElyByTwoFactorTextBox.Text.Trim();
-        ViewModel.AddElyByAccountCommand.Execute(null);
     }
 
     private async void RemoveAccount_Click(object sender, RoutedEventArgs e)

--- a/docs/login-flow-book.md
+++ b/docs/login-flow-book.md
@@ -1,0 +1,1508 @@
+# Emerald Login Flow Book
+
+This document is a tour of the `noobnotfound/authentication` branch as compared with `main`.
+It focuses on the account and login flow: Microsoft, Ely.by OAuth, offline accounts, cancellation,
+selection, persistence, launch-time authentication, and authlib-injector wiring.
+
+The intent is to be a readable book for future work, not a terse PR summary.
+
+## Table Of Contents
+
+1. Branch verdict
+2. What changed compared to `main`
+3. Big mental model
+4. File map
+5. UI flow from button click to command
+6. ViewModel login state, cancellation, and navigation persistence
+7. CoreX account service layout
+8. Microsoft sign-in flow
+9. Ely.by OAuth sign-in flow
+10. Ely.by loopback browser callback flow
+11. Ely.by token exchange and account info flow
+12. Account storage and loading
+13. Launch-time authentication
+14. How authlib-injector enters the Minecraft process
+15. Removal and sign-out
+16. Tests added by the branch
+17. Future provider checklist
+18. Risks and follow-up notes
+
+## 1. Branch Verdict
+
+This branch is a real account architecture refactor, not just an Ely.by patch.
+
+The useful part is that authentication is now split into provider-shaped pieces:
+
+- Microsoft provider
+- Offline provider
+- Ely.by provider
+- shared account service orchestration
+- provider-specific storage and token handling
+- launch-time runtime auth options
+
+That is the right direction for supporting more auth systems later. `AccountService` still owns account
+selection, persistence, and user-facing orchestration, but the provider-specific auth details are no longer
+stuffed directly into one huge class.
+
+The two biggest product changes are:
+
+- Ely.by browser OAuth is supported.
+- Microsoft and Ely.by sign-in can be canceled from the UI, and the in-progress login is no longer lost when navigating away from the Accounts page.
+
+The biggest risk is secret handling: Ely.by `client_secret` currently lives in `App.xaml.cs`. That works for now,
+but it is not ideal for source control or public distribution.
+
+## 2. What Changed Compared To `main`
+
+Branch:
+
+```text
+noobnotfound/authentication
+```
+
+Commits ahead of `main`:
+
+```text
+2e54926 Add Ely.by account support and auth providers
+b1ac52c Temporary disable MS requirement
+f302192 Add Ely.by OAuth browser sign-in & refresh
+9455941 Support cancelable account sign-in flows
+```
+
+High-level diff:
+
+```text
+40 files changed
+2528 insertions
+574 deletions
+```
+
+Main categories:
+
+- `AccountService` was split into partial files.
+- Account authentication now uses `IAccountAuthenticationProvider`.
+- `EAccount` now has `AccountType.ElyBy` and `ProviderId`.
+- Ely.by account storage was added under `SettingsKeys.ElyByAccounts`.
+- Ely.by OAuth token exchange, refresh, and account info calls were added.
+- Browser loopback OAuth callback handling was added in the Uno app layer.
+- authlib-injector download and JVM argument injection were added.
+- `GameAuthenticationResult` now carries both a CmlLib `MSession` and runtime auth options.
+- The Accounts page now has a cancel login button.
+- `AccountsPageViewModel` is singleton-scoped so login state survives navigation away/back.
+
+## 3. Big Mental Model
+
+There are two phases:
+
+1. Account sign-in
+2. Game launch authentication
+
+Sign-in is when the account is added to Emerald.
+Launch authentication is when Emerald turns a selected stored account into a CmlLib `MSession` and, for Ely.by,
+adds authlib-injector JVM arguments.
+
+```mermaid
+flowchart TD
+    A["Accounts UI"] --> B["AccountsPageViewModel"]
+    B --> C["IAccountService"]
+    C --> D["Microsoft client"]
+    C --> E["Ely.by auth client"]
+    C --> F["Ely.by loopback browser"]
+    C --> G["Ely.by account store"]
+    C --> H["Settings persistence"]
+
+    I["Launch game"] --> J["GameRuntimeService"]
+    J --> K["IAccountService.AuthenticateAccountAsync"]
+    K --> L["IAccountAuthenticationProvider"]
+    L --> M["MSession"]
+    L --> N["Runtime auth options"]
+    N --> O["Extra JVM args"]
+    M --> P["Game.BuildProcess"]
+    O --> P
+```
+
+The core abstraction is:
+
+```csharp
+public interface IAccountAuthenticationProvider
+{
+    AccountType AccountType { get; }
+    string ProviderId { get; }
+    Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default);
+    Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default);
+}
+```
+
+Line by line:
+
+- `public interface IAccountAuthenticationProvider`: defines a provider contract for a kind of account.
+- `AccountType AccountType`: tells `AccountService` which `EAccount.Type` this provider handles.
+- `string ProviderId`: gives a stable string identity such as `microsoft`, `offline`, or `elyby`.
+- `AuthenticateAsync(...)`: turns a stored/listed Emerald account into launch credentials.
+- `RemoveAsync(...)`: lets the provider perform provider-specific cleanup when removing an account.
+
+## 4. File Map
+
+### Uno App Layer
+
+| File | Role |
+| --- | --- |
+| `Emerald/App.xaml.cs` | DI composition root. Registers Ely OAuth options, Ely client, Ely browser, authlib-injector, account service, viewmodels. |
+| `Emerald/Views/AccountsPage.xaml` | Accounts UI. Buttons for Microsoft, Ely.by, offline, cancel login, account list. |
+| `Emerald/Views/AccountsPage.xaml.cs` | Page glue. Creates offline dialog and forwards account remove/select clicks to the viewmodel. |
+| `Emerald/ViewModels/AccountsPageViewModel.cs` | UI state and commands for account loading, sign-in, cancellation, removal, selection. |
+| `Emerald/Services/ElyByLoopbackOAuthBrowser.cs` | App/platform-specific browser OAuth implementation using `HttpListener` and `Launcher.LaunchUriAsync`. |
+
+### CoreX Layer
+
+| File | Role |
+| --- | --- |
+| `Emerald.CoreX/Services/IAccountService.cs` | Public account service contract used by UI/runtime. |
+| `Emerald.CoreX/Services/AccountService.cs` | Constructor, fields, initialization, provider registration. |
+| `Emerald.CoreX/Services/AccountService.SignIn.cs` | Offline creation, Microsoft sign-in, Ely.by sign-in. |
+| `Emerald.CoreX/Services/AccountService.Loading.cs` | Loads offline, Microsoft, and Ely.by accounts into the observable account list. |
+| `Emerald.CoreX/Services/AccountService.Authentication.cs` | Authenticates selected accounts for launch and removes accounts. |
+| `Emerald.CoreX/Services/AccountService.Selection.cs` | Selection state and account policy enforcement. |
+| `Emerald.CoreX/Services/AccountService.Persistence.cs` | Persists visible account list and selected account id. |
+| `Emerald.CoreX/Services/Auth/*` | Provider contracts, provider IDs, runtime auth options, auth provider implementations. |
+| `Emerald.CoreX/Services/Auth/ElyBy/*` | Ely.by OAuth/direct auth, account store, stored model, browser contract. |
+| `Emerald.CoreX/Services/Auth/Authlib/*` | authlib-injector download and JVM arg creation. |
+
+### Runtime Layer
+
+| File | Role |
+| --- | --- |
+| `Emerald.CoreX/Runtime/GameRuntimeService.cs` | Calls account authentication before building a Minecraft process. |
+| `Emerald.CoreX/Game.cs` | Receives session and extra JVM args, builds CmlLib launch options. |
+
+## 5. UI Flow From Button Click To Command
+
+The Accounts toolbar is in `Emerald/Views/AccountsPage.xaml`.
+
+Core snippet:
+
+```xml
+<AppBarButton
+  Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}"
+  Icon="Contact"
+  Label="{helpers:Localize KeyName=SignInWithMS}"
+  IsEnabled="{x:Bind ViewModel.CanStartMicrosoftLogin, Mode=OneWay}"/>
+
+<AppBarButton
+  Command="{x:Bind ViewModel.AddElyByAccountCommand}"
+  Icon="World"
+  Label="{helpers:Localize KeyName=SignInWithElyBy}"
+  IsEnabled="{x:Bind ViewModel.CanStartElyByLogin, Mode=OneWay}"/>
+
+<AppBarButton
+  Command="{x:Bind ViewModel.CancelLoginCommand}"
+  Icon="Cancel"
+  Label="{helpers:Localize KeyName=CancelLogin}"
+  Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
+```
+
+Line by line:
+
+- `Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}"`: binds the Microsoft button to the relay command generated from `AddMicrosoftAccountAsync`.
+- `Icon="Contact"`: uses a built-in app bar icon.
+- `Label="{helpers:Localize KeyName=SignInWithMS}"`: gets the button text from resources.
+- `IsEnabled="{x:Bind ViewModel.CanStartMicrosoftLogin, Mode=OneWay}"`: disables Microsoft login while another login is running.
+- `Command="{x:Bind ViewModel.AddElyByAccountCommand}"`: binds the Ely.by button to the generated Ely command.
+- `Icon="World"`: visual hint for an external/online provider.
+- `Label="{helpers:Localize KeyName=SignInWithElyBy}"`: localized Ely button label.
+- `IsEnabled="{x:Bind ViewModel.CanStartElyByLogin, Mode=OneWay}"`: disables Ely if policy disallows it or another login is active.
+- `Command="{x:Bind ViewModel.CancelLoginCommand}"`: binds Cancel to the generated cancellation command.
+- `Icon="Cancel"`: standard cancel icon.
+- `Label="{helpers:Localize KeyName=CancelLogin}"`: localized cancel label.
+- `Visibility="{x:Bind ViewModel.IsLoginInProgress ...}"`: the cancel button only appears while a login is in progress.
+
+The loading panel repeats the cancel affordance:
+
+```xml
+<StackPanel
+  Spacing="12"
+  HorizontalAlignment="Center"
+  Margin="0,48,0,0"
+  Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}">
+  <ProgressRing IsActive="True"/>
+  <TextBlock Text="{x:Bind ViewModel.LoadingMessage, Mode=OneWay}" TextAlignment="Center"/>
+  <Button
+    HorizontalAlignment="Center"
+    Command="{x:Bind ViewModel.CancelLoginCommand}"
+    Content="{helpers:Localize KeyName=CancelLogin}"
+    Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
+</StackPanel>
+```
+
+Line by line:
+
+- `Visibility="{x:Bind ViewModel.IsLoading ...}"`: panel appears during account load or active sign-in.
+- `ProgressRing IsActive="True"`: shows indeterminate progress.
+- `TextBlock Text="{x:Bind ViewModel.LoadingMessage ...}"`: displays either `Loading accounts...` or provider-specific login status.
+- `Button Command="{x:Bind ViewModel.CancelLoginCommand}"`: gives the user a second obvious cancel target in the center of the page.
+- `Content="{helpers:Localize KeyName=CancelLogin}"`: localizes the button text.
+- `Visibility="{x:Bind ViewModel.IsLoginInProgress ...}"`: hides the cancel button for normal account loading.
+
+## 6. ViewModel Login State, Cancellation, And Navigation Persistence
+
+The viewmodel is registered as a singleton:
+
+```csharp
+services.AddSingleton<ViewModels.AccountsPageViewModel>();
+```
+
+Why this matters:
+
+- Before this, navigating away from Accounts and back could create a new viewmodel.
+- A new viewmodel would not know about the running login task.
+- Now the viewmodel instance lives for the app lifetime.
+- Its `IsLoginInProgress`, cancellation source, and loading message survive page recreation.
+
+### Fields And Observable State
+
+Snippet:
+
+```csharp
+private readonly IAccountService _accountService;
+private readonly INotificationService _notificationService;
+private readonly ILogger<AccountsPageViewModel> _logger;
+private CancellationTokenSource? _loginCancellationSource;
+
+[ObservableProperty]
+[NotifyPropertyChangedFor(nameof(LoadingMessage))]
+private bool _isLoading;
+
+[ObservableProperty]
+[NotifyPropertyChangedFor(nameof(LoadingMessage))]
+[NotifyPropertyChangedFor(nameof(CanStartMicrosoftLogin))]
+[NotifyPropertyChangedFor(nameof(CanStartElyByLogin))]
+[NotifyPropertyChangedFor(nameof(CanStartOfflineAccount))]
+[NotifyPropertyChangedFor(nameof(CanCancelLogin))]
+[NotifyCanExecuteChangedFor(nameof(AddMicrosoftAccountCommand))]
+[NotifyCanExecuteChangedFor(nameof(AddElyByAccountCommand))]
+[NotifyCanExecuteChangedFor(nameof(AddOfflineAccountCommand))]
+[NotifyCanExecuteChangedFor(nameof(CancelLoginCommand))]
+private bool _isLoginInProgress;
+```
+
+Line by line:
+
+- `_accountService`: the CoreX service that owns account operations.
+- `_notificationService`: the app notification surface for success, warnings, and errors.
+- `_logger`: diagnostic logging for failures and cancellation.
+- `_loginCancellationSource`: the active login cancellation source. `null` means no login is active.
+- `[ObservableProperty]` on `_isLoading`: CommunityToolkit generates `IsLoading` and change notifications.
+- `[NotifyPropertyChangedFor(nameof(LoadingMessage))]`: whenever `IsLoading` changes, also notify that `LoadingMessage` may need to refresh.
+- `[ObservableProperty]` on `_isLoginInProgress`: generates `IsLoginInProgress`.
+- Notify lines for `CanStart...`: the UI enablement properties depend on login state.
+- Notify lines for commands: command `CanExecute` needs to be recalculated when login state changes.
+
+### Gate Properties
+
+Snippet:
+
+```csharp
+public bool CanStartMicrosoftLogin => !IsLoginInProgress;
+public bool CanStartElyByLogin => CanCreateElyByAccount && !IsLoginInProgress;
+public bool CanStartOfflineAccount => CanCreateOfflineAccount && !IsLoginInProgress;
+public bool CanCancelLogin
+    => IsLoginInProgress && _loginCancellationSource is { IsCancellationRequested: false };
+public string LoadingMessage => IsLoginInProgress ? LoginStatusMessage : "Loading accounts...";
+```
+
+Line by line:
+
+- `CanStartMicrosoftLogin`: Microsoft login is allowed only when no login is already active.
+- `CanStartElyByLogin`: Ely login also checks the Ely policy gate.
+- `CanStartOfflineAccount`: offline account creation also waits for active login to finish.
+- `CanCancelLogin`: true only while there is an active, uncanceled cancellation source.
+- `LoadingMessage`: provider-specific message during login, generic message during normal loading.
+
+### Microsoft Command
+
+Snippet:
+
+```csharp
+[RelayCommand(CanExecute = nameof(CanStartMicrosoftLogin))]
+private async Task AddMicrosoftAccountAsync()
+{
+    var cancellationToken = BeginLogin("Complete Microsoft sign-in in your browser.");
+    try
+    {
+        await _accountService.SignInMicrosoftAccountAsync(cancellationToken);
+        _notificationService.Info("AccountAdded", "Microsoft account added successfully!");
+        NotifyAccountStateChanged();
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        _logger.LogInformation("Microsoft sign-in was canceled.");
+        LoadErrorMessage = null;
+        _notificationService.Info("SignInCanceled", "Microsoft sign-in canceled.");
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to sign in with Microsoft account.");
+        LoadErrorMessage = "Failed to add Microsoft account.";
+        _notificationService.Error("SignInError", "Failed to add Microsoft account.", ex: ex);
+    }
+    finally
+    {
+        EndLogin(cancellationToken);
+    }
+}
+```
+
+Line by line:
+
+- `[RelayCommand(...)]`: CommunityToolkit generates `AddMicrosoftAccountCommand`.
+- `CanExecute = nameof(CanStartMicrosoftLogin)`: command disables itself when a login is active.
+- `BeginLogin(...)`: creates the cancellation token and flips UI into login mode.
+- `try`: all sign-in outcomes are handled in one place.
+- `_accountService.SignInMicrosoftAccountAsync(cancellationToken)`: delegates actual Microsoft auth to CoreX.
+- Success notification: tells the user the account was added.
+- `NotifyAccountStateChanged()`: refreshes selected account and account creation gate properties.
+- `catch (OperationCanceledException) when (...)`: treats user cancellation as normal, not as an error.
+- Log line: records cancellation for diagnostics.
+- `LoadErrorMessage = null`: cancellation should not leave an error banner.
+- cancellation info notification: tells the user the cancel button worked.
+- generic `catch`: real failures are logged and surfaced as errors.
+- `finally`: always clears the login UI state if this is still the active token.
+
+### Ely.by Command
+
+Snippet:
+
+```csharp
+[RelayCommand(CanExecute = nameof(CanStartElyByLogin))]
+private async Task AddElyByAccountAsync()
+{
+    if (!CanCreateElyByAccount)
+    {
+        _notificationService.Warning("ElyByNeedsMicrosoft", "Sign in with a Microsoft account before adding Ely.by accounts.");
+        return;
+    }
+
+    var cancellationToken = BeginLogin("Complete Ely.by sign-in in your browser.");
+    try
+    {
+        _notificationService.Info("UsingBrowser", "Complete Ely.by sign-in in your browser.");
+        await _accountService.SignInElyByAccountAsync(cancellationToken);
+        _notificationService.Info("AccountAdded", "Ely.by account added successfully!");
+        NotifyAccountStateChanged();
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        _logger.LogInformation("Ely.by sign-in was canceled.");
+        LoadErrorMessage = null;
+        _notificationService.Info("SignInCanceled", "Ely.by sign-in canceled.");
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to sign in with Ely.by account.");
+        LoadErrorMessage = "Failed to add Ely.by account.";
+        _notificationService.Error("ElyBySignInError", "Failed to add Ely.by account.", ex: ex);
+    }
+    finally
+    {
+        EndLogin(cancellationToken);
+    }
+}
+```
+
+Line by line:
+
+- `[RelayCommand(CanExecute = nameof(CanStartElyByLogin))]`: generates `AddElyByAccountCommand`.
+- `if (!CanCreateElyByAccount)`: defensive policy check. Currently policy is disabled, but the guard remains.
+- warning notification: explains what would be needed if policy is enabled later.
+- `BeginLogin(...)`: starts persistent/cancelable login state.
+- browser info notification: tells user to look at the browser.
+- `_accountService.SignInElyByAccountAsync(cancellationToken)`: calls CoreX Ely OAuth flow.
+- success notification: confirms stored account was created.
+- cancellation catch: handles cancel cleanly.
+- generic catch: real Ely failures become error notifications.
+- `finally`: guarantees UI cleanup.
+
+### Cancel Command
+
+Snippet:
+
+```csharp
+[RelayCommand(CanExecute = nameof(CanCancelLogin))]
+private void CancelLogin()
+{
+    if (_loginCancellationSource is not { IsCancellationRequested: false })
+    {
+        return;
+    }
+
+    LoginStatusMessage = "Canceling sign-in...";
+    _loginCancellationSource.Cancel();
+    NotifyLoginCommandStateChanged();
+}
+```
+
+Line by line:
+
+- `[RelayCommand(CanExecute = nameof(CanCancelLogin))]`: generates a command that is enabled only during cancelable login.
+- `if (...) return`: avoids double-cancel and null cases.
+- `LoginStatusMessage = "Canceling sign-in..."`: immediately updates the UI status text.
+- `_loginCancellationSource.Cancel()`: signals cancellation to Microsoft or Ely code.
+- `NotifyLoginCommandStateChanged()`: disables Cancel after it has been clicked.
+
+### Begin And End Login
+
+Snippet:
+
+```csharp
+private CancellationToken BeginLogin(string statusMessage)
+{
+    _loginCancellationSource?.Dispose();
+    _loginCancellationSource = new CancellationTokenSource();
+    LoginStatusMessage = statusMessage;
+    LoadErrorMessage = null;
+    IsLoginInProgress = true;
+    IsLoading = true;
+    NotifyAccountStateChanged();
+    NotifyLoginCommandStateChanged();
+    return _loginCancellationSource.Token;
+}
+```
+
+Line by line:
+
+- Dispose old cancellation source if one somehow exists.
+- Create a new cancellation source for this specific login.
+- Set the text the loading panel shows.
+- Clear old load/sign-in error text.
+- Mark login as active.
+- Mark page as loading so the spinner/panel appears.
+- Notify dependent account properties.
+- Notify command enablement.
+- Return the token that will be passed through the whole auth stack.
+
+Snippet:
+
+```csharp
+private void EndLogin(CancellationToken cancellationToken)
+{
+    if (_loginCancellationSource is null || !_loginCancellationSource.Token.Equals(cancellationToken))
+    {
+        return;
+    }
+
+    _loginCancellationSource.Dispose();
+    _loginCancellationSource = null;
+    IsLoginInProgress = false;
+    LoginStatusMessage = "Loading accounts...";
+    IsLoading = false;
+    NotifyAccountStateChanged();
+    NotifyLoginCommandStateChanged();
+}
+```
+
+Line by line:
+
+- Checks this completion belongs to the active login.
+- If a newer login ever exists, the old one cannot clear the new state.
+- Dispose the source.
+- Clear the active source.
+- Mark login inactive.
+- Reset loading message.
+- Hide loading spinner/panel.
+- Refresh dependent account state.
+- Refresh command enabled/disabled state.
+
+## 7. CoreX Account Service Layout
+
+`AccountService` is now a partial class. The split is mostly organizational:
+
+- `AccountService.cs`: fields, constructor, DI fallback defaults, initialization.
+- `AccountService.SignIn.cs`: sign-in and account creation.
+- `AccountService.Loading.cs`: load account list from stores.
+- `AccountService.Authentication.cs`: authenticate/remove account.
+- `AccountService.Selection.cs`: selected account state.
+- `AccountService.Persistence.cs`: settings persistence.
+
+### Constructor And Provider Registration
+
+Snippet:
+
+```csharp
+internal AccountService(
+    ILogger<AccountService> logger,
+    IBaseSettingsService settingsService,
+    IUiDispatcher uiDispatcher,
+    string? accountStorePath = null,
+    IMicrosoftAccountClient? microsoftAccountClient = null,
+    INotificationService? notificationService = null,
+    IElyByAuthClient? elyByAuthClient = null,
+    IElyByAccountStore? elyByAccountStore = null,
+    IElyByOAuthBrowser? elyByOAuthBrowser = null,
+    IAuthlibInjectorService? authlibInjectorService = null,
+    IEnumerable<IAccountAuthenticationProvider>? authenticationProviders = null)
+```
+
+Line by line:
+
+- `ILogger<AccountService>`: logs account operations.
+- `IBaseSettingsService`: JSON-backed settings store.
+- `IUiDispatcher`: ensures observable collection mutations happen on the UI thread.
+- `accountStorePath`: CmlLib Microsoft account cache path.
+- `IMicrosoftAccountClient?`: optional injected Microsoft client for tests or app DI.
+- `INotificationService?`: optional notifications for account loading warnings.
+- `IElyByAuthClient?`: optional injected Ely client.
+- `IElyByAccountStore?`: optional Ely persistence abstraction.
+- `IElyByOAuthBrowser?`: optional app-specific browser OAuth implementation.
+- `IAuthlibInjectorService?`: optional authlib-injector service.
+- `authenticationProviders`: optional fully custom providers for tests/future wiring.
+
+Provider defaults:
+
+```csharp
+return
+[
+    new OfflineAccountAuthenticationProvider(),
+    new MicrosoftAccountAuthenticationProvider(_microsoftAccountClient),
+    new ElyByAccountAuthenticationProvider(_elyByAccountStore, _elyByAuthClient, authlib)
+];
+```
+
+Line by line:
+
+- Offline provider is stateless and returns an offline session.
+- Microsoft provider wraps `IMicrosoftAccountClient`.
+- Ely provider needs Ely account storage, Ely token client, and authlib-injector.
+
+## 8. Microsoft Sign-In Flow
+
+The Microsoft flow still relies on CmlLib and XboxAuthNet MSAL.
+
+### App Startup Initialization
+
+`App.xaml.cs` has:
+
+```csharp
+private const string MicrosoftClientId = "...";
+```
+
+Then during launch:
+
+```csharp
+var ac = Ioc.Default.GetService<CoreX.Services.IAccountService>();
+_ = ac.InitializeAsync(MicrosoftClientId);
+```
+
+Meaning:
+
+- The app gets `IAccountService` from DI.
+- It starts Microsoft auth initialization in the background.
+- `AccountService.InitializeAsync(...)` delegates to `IMicrosoftAccountClient.InitializeAsync(...)`.
+
+### CmlLib Microsoft Client Setup
+
+Snippet:
+
+```csharp
+var app = await MsalClientHelper.BuildApplicationWithCache(clientId).ConfigureAwait(false);
+_loginHandler = new JELoginHandlerBuilder()
+    .WithLogger(_logger)
+    .WithOAuthProvider(new MsalCodeFlowProvider(app))
+    .WithAccountManager(accountStorePath)
+    .Build();
+```
+
+Line by line:
+
+- `MsalClientHelper.BuildApplicationWithCache(clientId)`: builds an MSAL client with token cache support.
+- `new JELoginHandlerBuilder()`: starts CmlLib Microsoft auth setup.
+- `.WithLogger(_logger)`: routes auth logs into Emerald logging.
+- `.WithOAuthProvider(new MsalCodeFlowProvider(app))`: tells CmlLib to use MSAL code flow.
+- `.WithAccountManager(accountStorePath)`: persists Microsoft accounts in a CmlLib account file.
+- `.Build()`: creates the `JELoginHandler`.
+
+### Interactive Sign-In With Cancellation
+
+Snippet:
+
+```csharp
+public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync(CancellationToken cancellationToken = default)
+{
+    EnsureInitialized();
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var interactiveTask = _loginHandler!.AuthenticateInteractively();
+    MSession session;
+    try
+    {
+        session = await interactiveTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        ObserveInteractiveSignInAfterCancellation(interactiveTask);
+        throw;
+    }
+
+    cancellationToken.ThrowIfCancellationRequested();
+    SaveAccounts();
+
+    return new MicrosoftInteractiveSignInResult(
+        Normalize(session.UUID),
+        Normalize(session.Username),
+        Normalize(session.UUID));
+}
+```
+
+Line by line:
+
+- Method returns a small normalized result instead of exposing all CmlLib details.
+- `EnsureInitialized()`: fails early if `InitializeAsync` was not called.
+- `ThrowIfCancellationRequested()`: handles cancel before opening/awaiting anything.
+- `AuthenticateInteractively()`: starts CmlLib browser/MSAL login.
+- `MSession session;`: will hold the authenticated Minecraft session.
+- `try`: wraps the await so cancellation can be handled specially.
+- `WaitAsync(cancellationToken)`: lets Emerald stop waiting when user clicks Cancel.
+- cancellation catch: only handles user-requested cancellation.
+- `ObserveInteractiveSignInAfterCancellation(...)`: prevents an abandoned task exception from being unobserved later.
+- `throw`: keeps cancellation flowing to the viewmodel.
+- second `ThrowIfCancellationRequested()`: if cancellation happens immediately after auth completes, do not persist.
+- `SaveAccounts()`: writes CmlLib account cache.
+- return result with identifier/name/uuid.
+
+Important nuance:
+
+Canceling Microsoft here means Emerald stops waiting and will not materialize the account. It cannot forcibly close
+the external browser or cancel every internal MSAL/CmlLib operation once launched.
+
+### AccountService Microsoft Materialization
+
+Snippet:
+
+```csharp
+var beforeIdentifiers = _microsoftAccountClient
+    .GetAccounts()
+    .Select(account => account.Identifier)
+    .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
+    .ToHashSet(StringComparer.Ordinal);
+
+var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync(cancellationToken).ConfigureAwait(false);
+
+var afterAccounts = _microsoftAccountClient.GetAccounts();
+await LoadAllAccountsAsync().ConfigureAwait(false);
+
+var candidateIdentifiers = BuildMaterializationCandidates(
+    signInResult,
+    beforeIdentifiers,
+    afterAccounts,
+    _microsoftAccountClient.GetDefaultAccountIdentifier());
+```
+
+Line by line:
+
+- Capture Microsoft account identifiers before sign-in.
+- Start interactive sign-in.
+- Read accounts after sign-in.
+- Reload Emerald account list from CmlLib plus settings.
+- Build a candidate identifier list to find which loaded account corresponds to the new sign-in.
+
+Why candidate matching exists:
+
+- CmlLib/MSAL can return different identifiers depending on account state.
+- New account may be found by returned UUID, newly added account, default account, or most recent account.
+- The branch tries those in order instead of assuming one field is always correct.
+
+## 9. Ely.by OAuth Sign-In Flow
+
+This is the central new flow.
+
+### OAuth Options
+
+Snippet:
+
+```csharp
+internal sealed record ElyByOAuthOptions(
+    string ClientId,
+    string ClientSecret,
+    string RedirectUri,
+    string Scope = ElyByOAuthOptions.DefaultScope)
+{
+    public const string DefaultScope = "account_info offline_access minecraft_server_session";
+
+    public bool IsConfigured
+        => !IsPlaceholder(ClientId)
+           && !IsPlaceholder(ClientSecret)
+           && Uri.TryCreate(RedirectUri, UriKind.Absolute, out _);
+}
+```
+
+Line by line:
+
+- `ElyByOAuthOptions`: immutable-ish record for Ely OAuth configuration.
+- `ClientId`: Ely OAuth app client id.
+- `ClientSecret`: Ely OAuth app client secret.
+- `RedirectUri`: loopback callback URI.
+- `Scope`: defaults to the scopes Emerald needs.
+- `account_info`: lets Emerald fetch username/UUID.
+- `offline_access`: lets Emerald receive refresh tokens.
+- `minecraft_server_session`: makes the token suitable for Minecraft server session use.
+- `IsConfigured`: prevents placeholder or invalid values from being used.
+
+### App DI Registration
+
+Snippet with secret redacted here intentionally:
+
+```csharp
+private const string ElyByClientId = "emerald1";
+private const string ElyByClientSecret = "<redacted>";
+private const string ElyByRedirectUri = "http://127.0.0.1:58135/oauth/elyby/";
+
+services.AddSingleton<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>(_ =>
+    new CoreX.Services.Auth.ElyBy.ElyByOAuthOptions(
+        ElyByClientId,
+        ElyByClientSecret,
+        ElyByRedirectUri));
+```
+
+Line by line:
+
+- Client id is defined at app composition level.
+- Client secret is currently defined there too. This is functional but sensitive.
+- Redirect URI is the local callback URI.
+- DI registers `ElyByOAuthOptions` as singleton because config is app-wide.
+- `ElyByAuthClient` receives these options through DI.
+
+### AccountService Ely Sign-In
+
+Snippet:
+
+```csharp
+public async Task SignInElyByAccountAsync(CancellationToken cancellationToken = default)
+{
+    EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
+    cancellationToken.ThrowIfCancellationRequested();
+
+    var state = CreateOAuthState();
+    var authorizationRequest = _elyByAuthClient.CreateOAuthAuthorizationRequest(state);
+
+    _logger.LogInformation("Starting Ely.by browser sign-in.");
+    var authorizationResult = await _elyByOAuthBrowser
+        .AuthorizeAsync(authorizationRequest, cancellationToken)
+        .ConfigureAwait(false);
+    var session = await _elyByAuthClient
+        .ExchangeOAuthCodeAsync(authorizationResult.Code, cancellationToken)
+        .ConfigureAwait(false);
+
+    await AddOrUpdateElyBySessionAsync(session, cancellationToken).ConfigureAwait(false);
+    _logger.LogInformation("Ely.by account '{Name}' signed in through OAuth.", session.Name);
+}
+```
+
+Line by line:
+
+- `EnsureElyByAccountPolicyMet(...)`: checks the Microsoft-required policy. Currently disabled, but still wired.
+- `ThrowIfCancellationRequested()`: cancels before doing OAuth work.
+- `CreateOAuthState()`: creates a random anti-CSRF state value.
+- `CreateOAuthAuthorizationRequest(state)`: builds the Ely authorization URL and redirect metadata.
+- log line: records that browser sign-in is starting.
+- `_elyByOAuthBrowser.AuthorizeAsync(...)`: app-layer browser flow opens the browser and waits for callback.
+- `authorizationResult.Code`: the OAuth authorization code from Ely.by.
+- `_elyByAuthClient.ExchangeOAuthCodeAsync(...)`: trades the code for access/refresh token and account info.
+- `AddOrUpdateElyBySessionAsync(...)`: persists the Ely account and updates the observable account list.
+- final log: confirms success.
+
+### OAuth State Generation
+
+Snippet:
+
+```csharp
+private static string CreateOAuthState()
+{
+    Span<byte> bytes = stackalloc byte[32];
+    RandomNumberGenerator.Fill(bytes);
+    return Convert.ToHexString(bytes).ToLowerInvariant();
+}
+```
+
+Line by line:
+
+- `Span<byte> bytes = stackalloc byte[32]`: creates 32 random bytes on the stack.
+- `RandomNumberGenerator.Fill(bytes)`: fills those bytes cryptographically.
+- `Convert.ToHexString(bytes)`: converts to hex.
+- `.ToLowerInvariant()`: normalizes casing for URL/state comparison.
+
+Why this matters:
+
+- The state prevents accepting random or malicious callbacks.
+- The browser callback must include the same state value.
+
+## 10. Ely.by Loopback Browser Callback Flow
+
+The browser implementation lives in the app layer because it uses platform/browser APIs.
+CoreX only knows `IElyByOAuthBrowser`.
+
+### Contract
+
+```csharp
+internal interface IElyByOAuthBrowser
+{
+    Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+        ElyByOAuthAuthorizationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record ElyByOAuthAuthorizationRequest(
+    Uri AuthorizationUri,
+    Uri RedirectUri,
+    string State);
+
+internal sealed record ElyByOAuthAuthorizationResult(string Code);
+```
+
+Line by line:
+
+- `IElyByOAuthBrowser`: abstraction so CoreX does not depend on Uno/WinUI browser details.
+- `AuthorizeAsync`: open browser, wait for OAuth result, return code.
+- `AuthorizationUri`: Ely URL to open.
+- `RedirectUri`: local URI to listen on.
+- `State`: state value expected in callback.
+- `ElyByOAuthAuthorizationResult`: currently only needs the authorization code.
+
+### Loopback Authorization
+
+Snippet:
+
+```csharp
+public async Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
+    ElyByOAuthAuthorizationRequest request,
+    CancellationToken cancellationToken = default)
+{
+    EnsureLoopbackRedirectUri(request.RedirectUri);
+
+    using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    timeoutSource.CancelAfter(AuthorizationTimeout);
+
+    using var listener = new HttpListener();
+    listener.Prefixes.Add(ToListenerPrefix(request.RedirectUri));
+    listener.Start();
+
+    var opened = await LaunchBrowserAsync(request.AuthorizationUri).ConfigureAwait(false);
+    if (!opened)
+        throw new ElyByAuthException("Could not open the Ely.by authorization page in your browser.");
+```
+
+Line by line:
+
+- Method receives the request from CoreX.
+- `EnsureLoopbackRedirectUri(...)`: validates URI is local loopback HTTP.
+- `CreateLinkedTokenSource(...)`: combines user cancel token with timeout token.
+- `CancelAfter(AuthorizationTimeout)`: enforces five-minute timeout.
+- `new HttpListener()`: creates a local HTTP listener for Ely redirect.
+- `Prefixes.Add(...)`: listens on the exact callback prefix.
+- `listener.Start()`: begins accepting callbacks.
+- `LaunchBrowserAsync(...)`: opens the system browser to Ely OAuth.
+- `if (!opened)`: if browser launch failed, throw an Ely auth exception.
+
+Callback loop:
+
+```csharp
+while (true)
+{
+    var context = await listener.GetContextAsync().WaitAsync(timeoutSource.Token).ConfigureAwait(false);
+    if (!IsExpectedCallback(request.RedirectUri, context.Request.Url))
+    {
+        await WriteHtmlResponseAsync(
+            context.Response,
+            404,
+            "Not found",
+            "This callback does not belong to the current Ely.by sign-in request.").ConfigureAwait(false);
+        continue;
+    }
+```
+
+Line by line:
+
+- `while (true)`: keep listening until valid callback, error, timeout, or cancel.
+- `GetContextAsync()`: waits for an HTTP request to the local listener.
+- `WaitAsync(timeoutSource.Token)`: makes listener wait cancelable.
+- `IsExpectedCallback(...)`: rejects wrong host/port/path.
+- `WriteHtmlResponseAsync(... 404 ...)`: tells the browser this was not the right callback.
+- `continue`: keep waiting for the actual callback.
+
+State and error handling:
+
+```csharp
+var query = context.Request.QueryString;
+var state = query["state"];
+if (!string.Equals(state, request.State, StringComparison.Ordinal))
+{
+    await WriteHtmlResponseAsync(
+        context.Response,
+        400,
+        "Sign-in rejected",
+        "The Ely.by sign-in response did not match the original request.").ConfigureAwait(false);
+    throw new ElyByAuthException("Ely.by sign-in returned an invalid OAuth state.");
+}
+
+var error = query["error"];
+if (!string.IsNullOrWhiteSpace(error))
+{
+    var message = query["error_message"] ?? query["error_description"] ?? error;
+    await WriteHtmlResponseAsync(context.Response, 400, "Sign-in cancelled", message).ConfigureAwait(false);
+    throw new ElyByAuthException(message);
+}
+```
+
+Line by line:
+
+- `query`: reads OAuth callback query parameters.
+- `state`: extracts returned OAuth state.
+- state comparison: protects against mismatched callback.
+- failure HTML: browser shows a clear message.
+- throw: returns an auth failure to the viewmodel.
+- `error`: checks if Ely sent an OAuth error.
+- `message`: chooses the best available human-readable error.
+- write HTML: browser displays cancellation/failure.
+- throw: app handles it as Ely sign-in failure.
+
+Code success handling:
+
+```csharp
+var code = query["code"];
+if (string.IsNullOrWhiteSpace(code))
+{
+    await WriteHtmlResponseAsync(
+        context.Response,
+        400,
+        "Sign-in failed",
+        "Ely.by did not return an authorization code.").ConfigureAwait(false);
+    throw new ElyByAuthException("Ely.by did not return an authorization code.");
+}
+
+await WriteHtmlResponseAsync(
+    context.Response,
+    200,
+    "Sign-in complete",
+    "You can close this browser tab and return to Emerald.").ConfigureAwait(false);
+return new ElyByOAuthAuthorizationResult(code);
+```
+
+Line by line:
+
+- `code`: extracts authorization code.
+- `if empty`: Ely did not return the expected code.
+- failure HTML and exception: surface a clear error.
+- success HTML: browser tells user they can return to Emerald.
+- return result: gives CoreX the code to exchange for tokens.
+
+Timeout and cleanup:
+
+```csharp
+catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+{
+    throw new ElyByAuthException("Timed out waiting for Ely.by browser sign-in to complete.");
+}
+finally
+{
+    listener.Stop();
+}
+```
+
+Line by line:
+
+- If the linked token canceled but the user token did not, it was timeout.
+- Timeout is reported as Ely auth failure, not user cancel.
+- `finally`: always stops the listener.
+
+## 11. Ely.by Token Exchange And Account Info Flow
+
+### Build Authorization URL
+
+Snippet:
+
+```csharp
+var parameters = new List<(string Key, string? Value)>
+{
+    ("client_id", oauthOptions.ClientId),
+    ("redirect_uri", oauthOptions.RedirectUri),
+    ("response_type", "code"),
+    ("scope", oauthOptions.Scope),
+    ("state", state)
+};
+
+if (!string.IsNullOrWhiteSpace(loginHint))
+    parameters.Add(("login_hint", loginHint));
+
+var authorizationUri = new Uri(AccountBaseUri, "oauth2/v1?" + BuildQuery(parameters));
+return new ElyByOAuthAuthorizationRequest(authorizationUri, redirectUri, state);
+```
+
+Line by line:
+
+- Creates query parameter list.
+- `client_id`: identifies Emerald's Ely app.
+- `redirect_uri`: must match registered Ely app redirect URI.
+- `response_type=code`: requests authorization code flow.
+- `scope`: requests account info, refresh token, and Minecraft server session permission.
+- `state`: anti-CSRF state.
+- optional `login_hint`: can prefill/guide login later.
+- `BuildQuery(...)`: URL-encodes the parameters.
+- return request: packs URL, redirect URI, and expected state for browser handler.
+
+### Exchange Code
+
+Snippet:
+
+```csharp
+var response = await SendOAuthTokenRequestAsync(
+        new Dictionary<string, string>
+        {
+            ["client_id"] = oauthOptions.ClientId,
+            ["client_secret"] = oauthOptions.ClientSecret,
+            ["redirect_uri"] = oauthOptions.RedirectUri,
+            ["grant_type"] = "authorization_code",
+            ["code"] = code
+        },
+        cancellationToken)
+    .ConfigureAwait(false);
+
+return await CreateOAuthSessionAsync(response, fallbackRefreshToken: null, cancellationToken).ConfigureAwait(false);
+```
+
+Line by line:
+
+- Creates a form-urlencoded token request.
+- `client_id`: Ely OAuth app id.
+- `client_secret`: Ely OAuth app secret.
+- `redirect_uri`: must match the authorization request.
+- `grant_type=authorization_code`: tells Ely this is code exchange.
+- `code`: one-time authorization code from callback.
+- `SendOAuthTokenRequestAsync(...)`: POSTs to Ely token endpoint.
+- `CreateOAuthSessionAsync(...)`: turns token response plus account info into Emerald session model.
+
+### Token Request Helper
+
+Snippet:
+
+```csharp
+using var content = new FormUrlEncodedContent(parameters);
+using var response = await _httpClient.PostAsync(OAuthTokenEndpoint, content, cancellationToken)
+    .ConfigureAwait(false);
+
+var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+if (response.IsSuccessStatusCode)
+{
+    var tokenResponse = JsonSerializer.Deserialize<ElyByOAuthTokenResponse>(body, JsonOptions);
+    return tokenResponse ?? throw new ElyByAuthException("Ely.by returned an empty OAuth token response.");
+}
+
+var error = TryDeserializeOAuthError(body);
+throw new ElyByAuthException(error?.ErrorDescription ?? error?.Error ?? $"Ely.by OAuth token request failed with status {(int)response.StatusCode}.");
+```
+
+Line by line:
+
+- `FormUrlEncodedContent`: OAuth token endpoint expects form fields.
+- `_httpClient.PostAsync(...)`: sends token request.
+- `ReadAsStringAsync(...)`: reads response body for success or error parsing.
+- `IsSuccessStatusCode`: only successful HTTP codes are parsed as token response.
+- `JsonSerializer.Deserialize`: maps JSON to `ElyByOAuthTokenResponse`.
+- null guard: prevents silent empty token response.
+- error parse: tries to get OAuth error details.
+- throw: surfaces a useful Ely auth exception.
+
+### Create OAuth Session
+
+Snippet:
+
+```csharp
+if (string.IsNullOrWhiteSpace(response.AccessToken))
+    throw new ElyByAuthException("Ely.by returned an OAuth response without an access token.");
+
+var accountInfo = await GetOAuthAccountInfoAsync(response.AccessToken, cancellationToken).ConfigureAwait(false);
+var uuid = NormalizeUuid(accountInfo.UUID);
+if (string.IsNullOrWhiteSpace(uuid))
+    throw new ElyByAuthException("Ely.by returned account info without a UUID.");
+
+if (string.IsNullOrWhiteSpace(accountInfo.Username))
+    throw new ElyByAuthException("Ely.by returned account info without a username.");
+```
+
+Line by line:
+
+- access token is mandatory.
+- account info is fetched using the access token.
+- UUID is normalized by removing hyphens.
+- missing UUID is fatal.
+- username is mandatory too.
+
+Session construction:
+
+```csharp
+var expiresAt = response.ExpiresIn > 0
+    ? DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn)
+    : (DateTimeOffset?)null;
+
+return new ElyByAuthSession(
+    accountInfo.Username,
+    uuid,
+    response.AccessToken,
+    Guid.NewGuid().ToString("N"),
+    string.IsNullOrWhiteSpace(response.RefreshToken) ? fallbackRefreshToken : response.RefreshToken,
+    expiresAt,
+    ElyByAuthFlow.OAuth);
+```
+
+Line by line:
+
+- `expiresAt`: stores absolute expiration time if Ely returns `expires_in`.
+- `accountInfo.Username`: Minecraft/Ely username.
+- `uuid`: normalized player UUID.
+- `response.AccessToken`: token used as Minecraft session access token.
+- `Guid.NewGuid().ToString("N")`: creates an internal client token because OAuth token response does not provide a Yggdrasil client token.
+- refresh token: keeps new refresh token, otherwise preserves old one during refresh.
+- `expiresAt`: used later to decide whether to refresh before launch.
+- `ElyByAuthFlow.OAuth`: marks this stored account as browser OAuth based.
+
+### Account Info Request
+
+Snippet:
+
+```csharp
+using var request = new HttpRequestMessage(HttpMethod.Get, AccountInfoEndpoint);
+request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+```
+
+Line by line:
+
+- Creates a GET request to Ely account info endpoint.
+- Adds `Authorization: Bearer <access token>`.
+- Sends request with cancellation support.
+
+## 12. Account Storage And Loading
+
+Ely accounts are stored separately from `MinecraftAccounts`.
+
+Key:
+
+```csharp
+public const string ElyByAccounts = "ElyByAccounts";
+```
+
+Stored model:
+
+```csharp
+internal sealed class ElyByStoredAccount
+{
+    public string UniqueId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string UUID { get; set; } = string.Empty;
+    public string AccessToken { get; set; } = string.Empty;
+    public string ClientToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTimeOffset? AccessTokenExpiresAt { get; set; }
+    public ElyByAuthFlow AuthFlow { get; set; } = ElyByAuthFlow.Direct;
+    public DateTime LastUsed { get; set; } = DateTime.UtcNow;
+}
+```
+
+Line by line:
+
+- `UniqueId`: Emerald stable account id, formatted like `elyby:<uuid>`.
+- `Name`: display/player name.
+- `UUID`: player UUID.
+- `AccessToken`: current Ely/Minecraft session token.
+- `ClientToken`: local client token used for session construction.
+- `RefreshToken`: OAuth refresh token.
+- `AccessTokenExpiresAt`: known access token expiry.
+- `AuthFlow`: `Direct` or `OAuth`, important for refresh behavior.
+- `LastUsed`: account sorting and display metadata.
+
+Loading:
+
+```csharp
+var storedElyByAccounts = _elyByAccountStore.GetAccounts()
+    .Select(CreateElyByAccount)
+    .ToList();
+```
+
+Line by line:
+
+- Reads Ely stored account records.
+- Converts them into visible `EAccount` objects.
+- Adds them to the account list alongside offline and Microsoft accounts.
+
+Creating visible account:
+
+```csharp
+private static EAccount CreateElyByAccount(ElyByStoredAccount account)
+    => new(
+        account.Name,
+        AccountType.ElyBy,
+        account.UUID,
+        account.UniqueId)
+    {
+        LastUsed = account.LastUsed == default ? DateTime.UtcNow : account.LastUsed,
+        ProviderId = AccountProviderIds.ElyBy
+    };
+```
+
+Line by line:
+
+- Uses stored name.
+- Sets type to `ElyBy`.
+- Sets UUID.
+- Preserves unique id.
+- Uses stored last-used value or current time fallback.
+- Sets stable provider id.
+
+## 13. Launch-Time Authentication
+
+Launch-time authentication begins in `GameRuntimeService`.
+
+Branch change:
+
+```csharp
+var authenticationResult = await _accountService.AuthenticateAccountAsync(account);
+
+var process = await game.BuildProcess(
+    game.Version.RealVersion,
+    authenticationResult.Session,
+    authenticationResult.RuntimeOptions);
+```
+
+Line by line:
+
+- Authenticates selected account just before launch.
+- Receives `GameAuthenticationResult`, not just `MSession`.
+- Sends the CmlLib session to `BuildProcess`.
+- Sends provider-specific runtime auth options too.
+
+`GameAuthenticationResult`:
+
+```csharp
+public sealed record GameAuthenticationResult(
+    MSession Session,
+    AccountRuntimeAuthOptions RuntimeOptions)
+{
+    public GameAuthenticationResult(MSession session)
+        : this(session, AccountRuntimeAuthOptions.Empty)
+    {
+    }
+}
+```
+
+Line by line:
+
+- `Session`: CmlLib session for launch.
+- `RuntimeOptions`: optional extra auth launch data.
+- Convenience constructor: providers without extra args can just pass session.
+- Default runtime options are empty.
+
+## 14. How authlib-injector Enters The Minecraft Process
+
+Ely.by needs authlib-injector so Minecraft uses Ely's auth/session endpoints.
+
+Ely provider:
+
+```csharp
+var javaAgentArgument = await authlibInjectorService.GetJavaAgentArgumentAsync(cancellationToken).ConfigureAwait(false);
+var runtimeOptions = new AccountRuntimeAuthOptions([new MArgument(javaAgentArgument)]);
+```
+
+Line by line:
+
+- Gets or downloads authlib-injector jar.
+- Returns a JVM `-javaagent` argument targeting Ely.
+- Wraps it as a CmlLib `MArgument`.
+- Packs that into `AccountRuntimeAuthOptions`.
+
+Authlib service:
+
+```csharp
+public async Task<string> GetJavaAgentArgumentAsync(CancellationToken cancellationToken = default)
+{
+    var jarPath = await EnsureJarAsync(cancellationToken).ConfigureAwait(false);
+    return $"-javaagent:{jarPath}=ely.by";
+}
+```
+
+Line by line:
+
+- `EnsureJarAsync`: makes sure jar exists locally.
+- returns `-javaagent:<path>=ely.by`.
+- That exact string is later appended to CmlLib launch JVM args.
+
+Game process build:
+
+```csharp
+if (runtimeAuthOptions?.ExtraJvmArguments.Count > 0)
+{
+    launchOpt.ExtraJvmArguments = launchOpt.ExtraJvmArguments
+        .Concat(runtimeAuthOptions.ExtraJvmArguments)
+        .ToArray();
+}
+```
+
+Line by line:
+
+- Checks whether the provider returned extra JVM auth arguments.
+- Takes existing game settings JVM args.
+- Concatenates provider JVM args.
+- Converts to array because CmlLib launch options expect array-like argument collection.
+
+## 15. Removal And Sign-Out
+
+Removal goes through `AccountService.RemoveAccountAsync`.
+
+Microsoft:
+
+```csharp
+if (account.Type == AccountType.Microsoft)
+{
+    await EnsureInitializedAsync().ConfigureAwait(false);
+    await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
+    await LoadAllAccountsAsync().ConfigureAwait(false);
+    return;
+}
+```
+
+Line by line:
+
+- Microsoft requires initialized CmlLib login handler.
+- Provider signs the Microsoft account out of CmlLib.
+- Reloads accounts from CmlLib/settings.
+- Returns early because reload handles collection updates.
+
+Ely.by:
+
+```csharp
+if (account.Type == AccountType.ElyBy)
+{
+    await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
+}
+```
+
+Line by line:
+
+- Ely provider handles Ely-specific cleanup.
+- For OAuth accounts, remote invalidation is skipped because no revoke endpoint is documented in the current implementation.
+- Account is removed from `ElyByAccounts` local settings.
+
+## 16. Tests Added By The Branch
+
+Important test coverage in `Emerald.CoreX.Tests/Services/AccountServiceTests.cs`:
+
+- `RequireMicrosoftAccountForOfflineAccounts_IsDisabled`
+- `RequireMicrosoftAccountForElyByAccounts_IsDisabled`
+- `SignInElyByAccountAsync_WithoutMicrosoftAccount_UsesBrowserOAuth`
+- `SignInElyByAccountAsync_CanceledDuringBrowserAuthorization_DoesNotAddAccount`
+- `SignInMicrosoftAccountAsync_CanceledDuringInteractiveSignIn_DoesNotMaterializeAccount`
+- `SignInElyByAccountAsync_AddsOAuthStoredAccount_AndSelectsWhenNoSelectionExists`
+- `AuthenticateAccountAsync_ElyByRefreshesExpiredToken_AndAddsAuthlibJavaAgent`
+- `AuthenticateAccountAsync_ElyByOAuthRefreshesExpiredAccessToken_AndAddsAuthlibJavaAgent`
+
+The cancellation tests are especially useful because they prove:
+
+- canceling Ely before callback does not exchange a code,
+- canceling Microsoft before completion does not materialize an account,
+- canceled flows do not add accounts accidentally.
+
+## 17. Future Provider Checklist
+
+The branch makes future auth providers easier. To add another provider, likely steps are:
+
+1. Add enum value to `AccountType`.
+2. Add provider id to `AccountProviderIds`.
+3. Add stored account model if the provider needs private token storage.
+4. Add account client abstraction for HTTP/OAuth/provider API.
+5. Add provider implementation of `IAccountAuthenticationProvider`.
+6. Register provider in `AccountService.CreateDefaultAuthenticationProviders`.
+7. Add sign-in method to `IAccountService` only if UI needs a custom sign-in flow.
+8. Add viewmodel command and UI button.
+9. Add tests for sign-in, refresh, launch authentication, removal, and cancellation.
+
+## 18. Risks And Follow-Up Notes
+
+### Secret in source
+
+`ElyByClientSecret` is currently in `App.xaml.cs`. This works but is risky. Better future options:
+
+- local developer secret file,
+- environment variable,
+- platform credential store,
+- server-side token exchange if public distribution needs to hide the secret.
+
+### Microsoft cancellation limitation
+
+`WaitAsync(cancellationToken)` makes Emerald stop waiting. It does not necessarily stop the browser or internal MSAL flow after launch.
+The implementation avoids materializing/storing after user cancellation.
+
+### OAuth token storage
+
+Ely OAuth refresh tokens are stored in app settings via `IBaseSettingsService`. That matches the current local persistence style,
+but refresh tokens are sensitive.
+
+### authlib-injector download
+
+First Ely launch may need network to download authlib-injector. If that fails, Ely launch auth fails.
+
+### Direct Ely auth still exists
+
+`ElyByAuthClient.AuthenticateAsync(login, password, twoFactorCode)` still exists for compatibility/testing, but the UI now uses OAuth.
+
+## End-To-End Ely.by Flow In One Pass
+
+1. User clicks `Sign in with Ely.by`.
+2. XAML invokes `ViewModel.AddElyByAccountCommand`.
+3. ViewModel creates cancellation token and sets `IsLoginInProgress`.
+4. ViewModel calls `IAccountService.SignInElyByAccountAsync(token)`.
+5. AccountService validates Ely policy.
+6. AccountService creates OAuth state.
+7. Ely client builds authorization URL.
+8. Ely loopback browser validates redirect URI.
+9. Loopback browser starts `HttpListener`.
+10. Loopback browser opens system browser.
+11. User signs in through Ely.by.
+12. Ely redirects to `http://127.0.0.1:58135/oauth/elyby/?code=...&state=...`.
+13. Loopback browser validates callback path and state.
+14. Loopback browser returns authorization code.
+15. Ely client exchanges code for token.
+16. Ely client calls account info endpoint with bearer token.
+17. Ely client builds `ElyByAuthSession`.
+18. AccountService converts session to `ElyByStoredAccount`.
+19. Ely store upserts into `SettingsKeys.ElyByAccounts`.
+20. AccountService adds or updates visible `EAccount`.
+21. AccountService selects it if no account was selected.
+22. ViewModel shows success and ends login state.
+
+## End-To-End Ely.by Launch Flow In One Pass
+
+1. User launches a game.
+2. Runtime gets selected account.
+3. Runtime calls `AuthenticateAccountAsync`.
+4. AccountService chooses Ely provider by `AccountType.ElyBy`.
+5. Ely provider finds stored Ely account.
+6. If OAuth token is expired or close to expired, provider refreshes it.
+7. Provider saves refreshed token data.
+8. Provider gets authlib-injector JVM argument.
+9. Provider creates CmlLib `MSession`.
+10. Provider returns `GameAuthenticationResult(session, runtimeOptions)`.
+11. Runtime calls `Game.BuildProcess(version, session, runtimeOptions)`.
+12. `Game.BuildProcess` sets `launchOpt.Session`.
+13. `Game.BuildProcess` appends authlib-injector JVM argument.
+14. CmlLib builds the Minecraft process.
+15. Minecraft starts with Ely-compatible authlib behavior.
+
+## End-To-End Cancel Flow In One Pass
+
+1. Login starts.
+2. ViewModel creates `_loginCancellationSource`.
+3. UI shows `Cancel login`.
+4. User clicks Cancel.
+5. ViewModel calls `_loginCancellationSource.Cancel()`.
+6. Ely loopback `WaitAsync(token)` or Microsoft `WaitAsync(token)` observes cancellation.
+7. Operation throws `OperationCanceledException`.
+8. ViewModel catches cancellation as a normal user action.
+9. ViewModel clears login state.
+10. No account is added from the canceled flow.
+


### PR DESCRIPTION
# Emerald Login Flow Book (Overview made with AI)

This document is a tour of the `noobnotfound/authentication` branch as compared with `main`.
It focuses on the account and login flow: Microsoft, Ely.by OAuth, offline accounts, cancellation,
selection, persistence, launch-time authentication, and authlib-injector wiring.

The intent is to be a readable book for future work, not a terse PR summary.

## Table Of Contents

1. Branch verdict
2. What changed compared to `main`
3. Big mental model
4. File map
5. UI flow from button click to command
6. ViewModel login state, cancellation, and navigation persistence
7. CoreX account service layout
8. Microsoft sign-in flow
9. Ely.by OAuth sign-in flow
10. Ely.by loopback browser callback flow
11. Ely.by token exchange and account info flow
12. Account storage and loading
13. Launch-time authentication
14. How authlib-injector enters the Minecraft process
15. Removal and sign-out
16. Tests added by the branch
17. Future provider checklist
18. Risks and follow-up notes

## 1. Branch Verdict

This branch is a real account architecture refactor, not just an Ely.by patch.

The useful part is that authentication is now split into provider-shaped pieces:

- Microsoft provider
- Offline provider
- Ely.by provider
- shared account service orchestration
- provider-specific storage and token handling
- launch-time runtime auth options

That is the right direction for supporting more auth systems later. `AccountService` still owns account
selection, persistence, and user-facing orchestration, but the provider-specific auth details are no longer
stuffed directly into one huge class.

The two biggest product changes are:

- Ely.by browser OAuth is supported.
- Microsoft and Ely.by sign-in can be canceled from the UI, and the in-progress login is no longer lost when navigating away from the Accounts page.

The biggest risk is secret handling: Ely.by `client_secret` currently lives in `App.xaml.cs`. That works for now,
but it is not ideal for source control or public distribution.

## 2. What Changed Compared To `main`

Branch:

```text
noobnotfound/authentication
```

Commits ahead of `main`:

```text
2e54926 Add Ely.by account support and auth providers
b1ac52c Temporary disable MS requirement
f302192 Add Ely.by OAuth browser sign-in & refresh
9455941 Support cancelable account sign-in flows
```

High-level diff:

```text
40 files changed
2528 insertions
574 deletions
```

Main categories:

- `AccountService` was split into partial files.
- Account authentication now uses `IAccountAuthenticationProvider`.
- `EAccount` now has `AccountType.ElyBy` and `ProviderId`.
- Ely.by account storage was added under `SettingsKeys.ElyByAccounts`.
- Ely.by OAuth token exchange, refresh, and account info calls were added.
- Browser loopback OAuth callback handling was added in the Uno app layer.
- authlib-injector download and JVM argument injection were added.
- `GameAuthenticationResult` now carries both a CmlLib `MSession` and runtime auth options.
- The Accounts page now has a cancel login button.
- `AccountsPageViewModel` is singleton-scoped so login state survives navigation away/back.

## 3. Big Mental Model

There are two phases:

1. Account sign-in
2. Game launch authentication

Sign-in is when the account is added to Emerald.
Launch authentication is when Emerald turns a selected stored account into a CmlLib `MSession` and, for Ely.by,
adds authlib-injector JVM arguments.

```mermaid
flowchart TD
    A["Accounts UI"] --> B["AccountsPageViewModel"]
    B --> C["IAccountService"]
    C --> D["Microsoft client"]
    C --> E["Ely.by auth client"]
    C --> F["Ely.by loopback browser"]
    C --> G["Ely.by account store"]
    C --> H["Settings persistence"]

    I["Launch game"] --> J["GameRuntimeService"]
    J --> K["IAccountService.AuthenticateAccountAsync"]
    K --> L["IAccountAuthenticationProvider"]
    L --> M["MSession"]
    L --> N["Runtime auth options"]
    N --> O["Extra JVM args"]
    M --> P["Game.BuildProcess"]
    O --> P
```

The core abstraction is:

```csharp
public interface IAccountAuthenticationProvider
{
    AccountType AccountType { get; }
    string ProviderId { get; }
    Task<GameAuthenticationResult> AuthenticateAsync(EAccount account, CancellationToken cancellationToken = default);
    Task RemoveAsync(EAccount account, CancellationToken cancellationToken = default);
}
```

Line by line:

- `public interface IAccountAuthenticationProvider`: defines a provider contract for a kind of account.
- `AccountType AccountType`: tells `AccountService` which `EAccount.Type` this provider handles.
- `string ProviderId`: gives a stable string identity such as `microsoft`, `offline`, or `elyby`.
- `AuthenticateAsync(...)`: turns a stored/listed Emerald account into launch credentials.
- `RemoveAsync(...)`: lets the provider perform provider-specific cleanup when removing an account.

## 4. File Map

### Uno App Layer

| File | Role |
| --- | --- |
| `Emerald/App.xaml.cs` | DI composition root. Registers Ely OAuth options, Ely client, Ely browser, authlib-injector, account service, viewmodels. |
| `Emerald/Views/AccountsPage.xaml` | Accounts UI. Buttons for Microsoft, Ely.by, offline, cancel login, account list. |
| `Emerald/Views/AccountsPage.xaml.cs` | Page glue. Creates offline dialog and forwards account remove/select clicks to the viewmodel. |
| `Emerald/ViewModels/AccountsPageViewModel.cs` | UI state and commands for account loading, sign-in, cancellation, removal, selection. |
| `Emerald/Services/ElyByLoopbackOAuthBrowser.cs` | App/platform-specific browser OAuth implementation using `HttpListener` and `Launcher.LaunchUriAsync`. |

### CoreX Layer

| File | Role |
| --- | --- |
| `Emerald.CoreX/Services/IAccountService.cs` | Public account service contract used by UI/runtime. |
| `Emerald.CoreX/Services/AccountService.cs` | Constructor, fields, initialization, provider registration. |
| `Emerald.CoreX/Services/AccountService.SignIn.cs` | Offline creation, Microsoft sign-in, Ely.by sign-in. |
| `Emerald.CoreX/Services/AccountService.Loading.cs` | Loads offline, Microsoft, and Ely.by accounts into the observable account list. |
| `Emerald.CoreX/Services/AccountService.Authentication.cs` | Authenticates selected accounts for launch and removes accounts. |
| `Emerald.CoreX/Services/AccountService.Selection.cs` | Selection state and account policy enforcement. |
| `Emerald.CoreX/Services/AccountService.Persistence.cs` | Persists visible account list and selected account id. |
| `Emerald.CoreX/Services/Auth/*` | Provider contracts, provider IDs, runtime auth options, auth provider implementations. |
| `Emerald.CoreX/Services/Auth/ElyBy/*` | Ely.by OAuth/direct auth, account store, stored model, browser contract. |
| `Emerald.CoreX/Services/Auth/Authlib/*` | authlib-injector download and JVM arg creation. |

### Runtime Layer

| File | Role |
| --- | --- |
| `Emerald.CoreX/Runtime/GameRuntimeService.cs` | Calls account authentication before building a Minecraft process. |
| `Emerald.CoreX/Game.cs` | Receives session and extra JVM args, builds CmlLib launch options. |

## 5. UI Flow From Button Click To Command

The Accounts toolbar is in `Emerald/Views/AccountsPage.xaml`.

Core snippet:

```xml
<AppBarButton
  Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}"
  Icon="Contact"
  Label="{helpers:Localize KeyName=SignInWithMS}"
  IsEnabled="{x:Bind ViewModel.CanStartMicrosoftLogin, Mode=OneWay}"/>

<AppBarButton
  Command="{x:Bind ViewModel.AddElyByAccountCommand}"
  Icon="World"
  Label="{helpers:Localize KeyName=SignInWithElyBy}"
  IsEnabled="{x:Bind ViewModel.CanStartElyByLogin, Mode=OneWay}"/>

<AppBarButton
  Command="{x:Bind ViewModel.CancelLoginCommand}"
  Icon="Cancel"
  Label="{helpers:Localize KeyName=CancelLogin}"
  Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
```

Line by line:

- `Command="{x:Bind ViewModel.AddMicrosoftAccountCommand}"`: binds the Microsoft button to the relay command generated from `AddMicrosoftAccountAsync`.
- `Icon="Contact"`: uses a built-in app bar icon.
- `Label="{helpers:Localize KeyName=SignInWithMS}"`: gets the button text from resources.
- `IsEnabled="{x:Bind ViewModel.CanStartMicrosoftLogin, Mode=OneWay}"`: disables Microsoft login while another login is running.
- `Command="{x:Bind ViewModel.AddElyByAccountCommand}"`: binds the Ely.by button to the generated Ely command.
- `Icon="World"`: visual hint for an external/online provider.
- `Label="{helpers:Localize KeyName=SignInWithElyBy}"`: localized Ely button label.
- `IsEnabled="{x:Bind ViewModel.CanStartElyByLogin, Mode=OneWay}"`: disables Ely if policy disallows it or another login is active.
- `Command="{x:Bind ViewModel.CancelLoginCommand}"`: binds Cancel to the generated cancellation command.
- `Icon="Cancel"`: standard cancel icon.
- `Label="{helpers:Localize KeyName=CancelLogin}"`: localized cancel label.
- `Visibility="{x:Bind ViewModel.IsLoginInProgress ...}"`: the cancel button only appears while a login is in progress.

The loading panel repeats the cancel affordance:

```xml
<StackPanel
  Spacing="12"
  HorizontalAlignment="Center"
  Margin="0,48,0,0"
  Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource BoolToVis}}">
  <ProgressRing IsActive="True"/>
  <TextBlock Text="{x:Bind ViewModel.LoadingMessage, Mode=OneWay}" TextAlignment="Center"/>
  <Button
    HorizontalAlignment="Center"
    Command="{x:Bind ViewModel.CancelLoginCommand}"
    Content="{helpers:Localize KeyName=CancelLogin}"
    Visibility="{x:Bind ViewModel.IsLoginInProgress, Mode=OneWay, Converter={StaticResource BoolToVis}}"/>
</StackPanel>
```

Line by line:

- `Visibility="{x:Bind ViewModel.IsLoading ...}"`: panel appears during account load or active sign-in.
- `ProgressRing IsActive="True"`: shows indeterminate progress.
- `TextBlock Text="{x:Bind ViewModel.LoadingMessage ...}"`: displays either `Loading accounts...` or provider-specific login status.
- `Button Command="{x:Bind ViewModel.CancelLoginCommand}"`: gives the user a second obvious cancel target in the center of the page.
- `Content="{helpers:Localize KeyName=CancelLogin}"`: localizes the button text.
- `Visibility="{x:Bind ViewModel.IsLoginInProgress ...}"`: hides the cancel button for normal account loading.

## 6. ViewModel Login State, Cancellation, And Navigation Persistence

The viewmodel is registered as a singleton:

```csharp
services.AddSingleton<ViewModels.AccountsPageViewModel>();
```

Why this matters:

- Before this, navigating away from Accounts and back could create a new viewmodel.
- A new viewmodel would not know about the running login task.
- Now the viewmodel instance lives for the app lifetime.
- Its `IsLoginInProgress`, cancellation source, and loading message survive page recreation.

### Fields And Observable State

Snippet:

```csharp
private readonly IAccountService _accountService;
private readonly INotificationService _notificationService;
private readonly ILogger<AccountsPageViewModel> _logger;
private CancellationTokenSource? _loginCancellationSource;

[ObservableProperty]
[NotifyPropertyChangedFor(nameof(LoadingMessage))]
private bool _isLoading;

[ObservableProperty]
[NotifyPropertyChangedFor(nameof(LoadingMessage))]
[NotifyPropertyChangedFor(nameof(CanStartMicrosoftLogin))]
[NotifyPropertyChangedFor(nameof(CanStartElyByLogin))]
[NotifyPropertyChangedFor(nameof(CanStartOfflineAccount))]
[NotifyPropertyChangedFor(nameof(CanCancelLogin))]
[NotifyCanExecuteChangedFor(nameof(AddMicrosoftAccountCommand))]
[NotifyCanExecuteChangedFor(nameof(AddElyByAccountCommand))]
[NotifyCanExecuteChangedFor(nameof(AddOfflineAccountCommand))]
[NotifyCanExecuteChangedFor(nameof(CancelLoginCommand))]
private bool _isLoginInProgress;
```

Line by line:

- `_accountService`: the CoreX service that owns account operations.
- `_notificationService`: the app notification surface for success, warnings, and errors.
- `_logger`: diagnostic logging for failures and cancellation.
- `_loginCancellationSource`: the active login cancellation source. `null` means no login is active.
- `[ObservableProperty]` on `_isLoading`: CommunityToolkit generates `IsLoading` and change notifications.
- `[NotifyPropertyChangedFor(nameof(LoadingMessage))]`: whenever `IsLoading` changes, also notify that `LoadingMessage` may need to refresh.
- `[ObservableProperty]` on `_isLoginInProgress`: generates `IsLoginInProgress`.
- Notify lines for `CanStart...`: the UI enablement properties depend on login state.
- Notify lines for commands: command `CanExecute` needs to be recalculated when login state changes.

### Gate Properties

Snippet:

```csharp
public bool CanStartMicrosoftLogin => !IsLoginInProgress;
public bool CanStartElyByLogin => CanCreateElyByAccount && !IsLoginInProgress;
public bool CanStartOfflineAccount => CanCreateOfflineAccount && !IsLoginInProgress;
public bool CanCancelLogin
    => IsLoginInProgress && _loginCancellationSource is { IsCancellationRequested: false };
public string LoadingMessage => IsLoginInProgress ? LoginStatusMessage : "Loading accounts...";
```

Line by line:

- `CanStartMicrosoftLogin`: Microsoft login is allowed only when no login is already active.
- `CanStartElyByLogin`: Ely login also checks the Ely policy gate.
- `CanStartOfflineAccount`: offline account creation also waits for active login to finish.
- `CanCancelLogin`: true only while there is an active, uncanceled cancellation source.
- `LoadingMessage`: provider-specific message during login, generic message during normal loading.

### Microsoft Command

Snippet:

```csharp
[RelayCommand(CanExecute = nameof(CanStartMicrosoftLogin))]
private async Task AddMicrosoftAccountAsync()
{
    var cancellationToken = BeginLogin("Complete Microsoft sign-in in your browser.");
    try
    {
        await _accountService.SignInMicrosoftAccountAsync(cancellationToken);
        _notificationService.Info("AccountAdded", "Microsoft account added successfully!");
        NotifyAccountStateChanged();
    }
    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
    {
        _logger.LogInformation("Microsoft sign-in was canceled.");
        LoadErrorMessage = null;
        _notificationService.Info("SignInCanceled", "Microsoft sign-in canceled.");
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, "Failed to sign in with Microsoft account.");
        LoadErrorMessage = "Failed to add Microsoft account.";
        _notificationService.Error("SignInError", "Failed to add Microsoft account.", ex: ex);
    }
    finally
    {
        EndLogin(cancellationToken);
    }
}
```

Line by line:

- `[RelayCommand(...)]`: CommunityToolkit generates `AddMicrosoftAccountCommand`.
- `CanExecute = nameof(CanStartMicrosoftLogin)`: command disables itself when a login is active.
- `BeginLogin(...)`: creates the cancellation token and flips UI into login mode.
- `try`: all sign-in outcomes are handled in one place.
- `_accountService.SignInMicrosoftAccountAsync(cancellationToken)`: delegates actual Microsoft auth to CoreX.
- Success notification: tells the user the account was added.
- `NotifyAccountStateChanged()`: refreshes selected account and account creation gate properties.
- `catch (OperationCanceledException) when (...)`: treats user cancellation as normal, not as an error.
- Log line: records cancellation for diagnostics.
- `LoadErrorMessage = null`: cancellation should not leave an error banner.
- cancellation info notification: tells the user the cancel button worked.
- generic `catch`: real failures are logged and surfaced as errors.
- `finally`: always clears the login UI state if this is still the active token.

### Ely.by Command

Snippet:

```csharp
[RelayCommand(CanExecute = nameof(CanStartElyByLogin))]
private async Task AddElyByAccountAsync()
{
    if (!CanCreateElyByAccount)
    {
        _notificationService.Warning("ElyByNeedsMicrosoft", "Sign in with a Microsoft account before adding Ely.by accounts.");
        return;
    }

    var cancellationToken = BeginLogin("Complete Ely.by sign-in in your browser.");
    try
    {
        _notificationService.Info("UsingBrowser", "Complete Ely.by sign-in in your browser.");
        await _accountService.SignInElyByAccountAsync(cancellationToken);
        _notificationService.Info("AccountAdded", "Ely.by account added successfully!");
        NotifyAccountStateChanged();
    }
    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
    {
        _logger.LogInformation("Ely.by sign-in was canceled.");
        LoadErrorMessage = null;
        _notificationService.Info("SignInCanceled", "Ely.by sign-in canceled.");
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, "Failed to sign in with Ely.by account.");
        LoadErrorMessage = "Failed to add Ely.by account.";
        _notificationService.Error("ElyBySignInError", "Failed to add Ely.by account.", ex: ex);
    }
    finally
    {
        EndLogin(cancellationToken);
    }
}
```

Line by line:

- `[RelayCommand(CanExecute = nameof(CanStartElyByLogin))]`: generates `AddElyByAccountCommand`.
- `if (!CanCreateElyByAccount)`: defensive policy check. Currently policy is disabled, but the guard remains.
- warning notification: explains what would be needed if policy is enabled later.
- `BeginLogin(...)`: starts persistent/cancelable login state.
- browser info notification: tells user to look at the browser.
- `_accountService.SignInElyByAccountAsync(cancellationToken)`: calls CoreX Ely OAuth flow.
- success notification: confirms stored account was created.
- cancellation catch: handles cancel cleanly.
- generic catch: real Ely failures become error notifications.
- `finally`: guarantees UI cleanup.

### Cancel Command

Snippet:

```csharp
[RelayCommand(CanExecute = nameof(CanCancelLogin))]
private void CancelLogin()
{
    if (_loginCancellationSource is not { IsCancellationRequested: false })
    {
        return;
    }

    LoginStatusMessage = "Canceling sign-in...";
    _loginCancellationSource.Cancel();
    NotifyLoginCommandStateChanged();
}
```

Line by line:

- `[RelayCommand(CanExecute = nameof(CanCancelLogin))]`: generates a command that is enabled only during cancelable login.
- `if (...) return`: avoids double-cancel and null cases.
- `LoginStatusMessage = "Canceling sign-in..."`: immediately updates the UI status text.
- `_loginCancellationSource.Cancel()`: signals cancellation to Microsoft or Ely code.
- `NotifyLoginCommandStateChanged()`: disables Cancel after it has been clicked.

### Begin And End Login

Snippet:

```csharp
private CancellationToken BeginLogin(string statusMessage)
{
    _loginCancellationSource?.Dispose();
    _loginCancellationSource = new CancellationTokenSource();
    LoginStatusMessage = statusMessage;
    LoadErrorMessage = null;
    IsLoginInProgress = true;
    IsLoading = true;
    NotifyAccountStateChanged();
    NotifyLoginCommandStateChanged();
    return _loginCancellationSource.Token;
}
```

Line by line:

- Dispose old cancellation source if one somehow exists.
- Create a new cancellation source for this specific login.
- Set the text the loading panel shows.
- Clear old load/sign-in error text.
- Mark login as active.
- Mark page as loading so the spinner/panel appears.
- Notify dependent account properties.
- Notify command enablement.
- Return the token that will be passed through the whole auth stack.

Snippet:

```csharp
private void EndLogin(CancellationToken cancellationToken)
{
    if (_loginCancellationSource is null || !_loginCancellationSource.Token.Equals(cancellationToken))
    {
        return;
    }

    _loginCancellationSource.Dispose();
    _loginCancellationSource = null;
    IsLoginInProgress = false;
    LoginStatusMessage = "Loading accounts...";
    IsLoading = false;
    NotifyAccountStateChanged();
    NotifyLoginCommandStateChanged();
}
```

Line by line:

- Checks this completion belongs to the active login.
- If a newer login ever exists, the old one cannot clear the new state.
- Dispose the source.
- Clear the active source.
- Mark login inactive.
- Reset loading message.
- Hide loading spinner/panel.
- Refresh dependent account state.
- Refresh command enabled/disabled state.

## 7. CoreX Account Service Layout

`AccountService` is now a partial class. The split is mostly organizational:

- `AccountService.cs`: fields, constructor, DI fallback defaults, initialization.
- `AccountService.SignIn.cs`: sign-in and account creation.
- `AccountService.Loading.cs`: load account list from stores.
- `AccountService.Authentication.cs`: authenticate/remove account.
- `AccountService.Selection.cs`: selected account state.
- `AccountService.Persistence.cs`: settings persistence.

### Constructor And Provider Registration

Snippet:

```csharp
internal AccountService(
    ILogger<AccountService> logger,
    IBaseSettingsService settingsService,
    IUiDispatcher uiDispatcher,
    string? accountStorePath = null,
    IMicrosoftAccountClient? microsoftAccountClient = null,
    INotificationService? notificationService = null,
    IElyByAuthClient? elyByAuthClient = null,
    IElyByAccountStore? elyByAccountStore = null,
    IElyByOAuthBrowser? elyByOAuthBrowser = null,
    IAuthlibInjectorService? authlibInjectorService = null,
    IEnumerable<IAccountAuthenticationProvider>? authenticationProviders = null)
```

Line by line:

- `ILogger<AccountService>`: logs account operations.
- `IBaseSettingsService`: JSON-backed settings store.
- `IUiDispatcher`: ensures observable collection mutations happen on the UI thread.
- `accountStorePath`: CmlLib Microsoft account cache path.
- `IMicrosoftAccountClient?`: optional injected Microsoft client for tests or app DI.
- `INotificationService?`: optional notifications for account loading warnings.
- `IElyByAuthClient?`: optional injected Ely client.
- `IElyByAccountStore?`: optional Ely persistence abstraction.
- `IElyByOAuthBrowser?`: optional app-specific browser OAuth implementation.
- `IAuthlibInjectorService?`: optional authlib-injector service.
- `authenticationProviders`: optional fully custom providers for tests/future wiring.

Provider defaults:

```csharp
return
[
    new OfflineAccountAuthenticationProvider(),
    new MicrosoftAccountAuthenticationProvider(_microsoftAccountClient),
    new ElyByAccountAuthenticationProvider(_elyByAccountStore, _elyByAuthClient, authlib)
];
```

Line by line:

- Offline provider is stateless and returns an offline session.
- Microsoft provider wraps `IMicrosoftAccountClient`.
- Ely provider needs Ely account storage, Ely token client, and authlib-injector.

## 8. Microsoft Sign-In Flow

The Microsoft flow still relies on CmlLib and XboxAuthNet MSAL.

### App Startup Initialization

`App.xaml.cs` has:

```csharp
private const string MicrosoftClientId = "...";
```

Then during launch:

```csharp
var ac = Ioc.Default.GetService<CoreX.Services.IAccountService>();
_ = ac.InitializeAsync(MicrosoftClientId);
```

Meaning:

- The app gets `IAccountService` from DI.
- It starts Microsoft auth initialization in the background.
- `AccountService.InitializeAsync(...)` delegates to `IMicrosoftAccountClient.InitializeAsync(...)`.

### CmlLib Microsoft Client Setup

Snippet:

```csharp
var app = await MsalClientHelper.BuildApplicationWithCache(clientId).ConfigureAwait(false);
_loginHandler = new JELoginHandlerBuilder()
    .WithLogger(_logger)
    .WithOAuthProvider(new MsalCodeFlowProvider(app))
    .WithAccountManager(accountStorePath)
    .Build();
```

Line by line:

- `MsalClientHelper.BuildApplicationWithCache(clientId)`: builds an MSAL client with token cache support.
- `new JELoginHandlerBuilder()`: starts CmlLib Microsoft auth setup.
- `.WithLogger(_logger)`: routes auth logs into Emerald logging.
- `.WithOAuthProvider(new MsalCodeFlowProvider(app))`: tells CmlLib to use MSAL code flow.
- `.WithAccountManager(accountStorePath)`: persists Microsoft accounts in a CmlLib account file.
- `.Build()`: creates the `JELoginHandler`.

### Interactive Sign-In With Cancellation

Snippet:

```csharp
public async Task<MicrosoftInteractiveSignInResult> SignInInteractivelyAsync(CancellationToken cancellationToken = default)
{
    EnsureInitialized();
    cancellationToken.ThrowIfCancellationRequested();

    var interactiveTask = _loginHandler!.AuthenticateInteractively();
    MSession session;
    try
    {
        session = await interactiveTask.WaitAsync(cancellationToken).ConfigureAwait(false);
    }
    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
    {
        ObserveInteractiveSignInAfterCancellation(interactiveTask);
        throw;
    }

    cancellationToken.ThrowIfCancellationRequested();
    SaveAccounts();

    return new MicrosoftInteractiveSignInResult(
        Normalize(session.UUID),
        Normalize(session.Username),
        Normalize(session.UUID));
}
```

Line by line:

- Method returns a small normalized result instead of exposing all CmlLib details.
- `EnsureInitialized()`: fails early if `InitializeAsync` was not called.
- `ThrowIfCancellationRequested()`: handles cancel before opening/awaiting anything.
- `AuthenticateInteractively()`: starts CmlLib browser/MSAL login.
- `MSession session;`: will hold the authenticated Minecraft session.
- `try`: wraps the await so cancellation can be handled specially.
- `WaitAsync(cancellationToken)`: lets Emerald stop waiting when user clicks Cancel.
- cancellation catch: only handles user-requested cancellation.
- `ObserveInteractiveSignInAfterCancellation(...)`: prevents an abandoned task exception from being unobserved later.
- `throw`: keeps cancellation flowing to the viewmodel.
- second `ThrowIfCancellationRequested()`: if cancellation happens immediately after auth completes, do not persist.
- `SaveAccounts()`: writes CmlLib account cache.
- return result with identifier/name/uuid.

Important nuance:

Canceling Microsoft here means Emerald stops waiting and will not materialize the account. It cannot forcibly close
the external browser or cancel every internal MSAL/CmlLib operation once launched.

### AccountService Microsoft Materialization

Snippet:

```csharp
var beforeIdentifiers = _microsoftAccountClient
    .GetAccounts()
    .Select(account => account.Identifier)
    .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
    .ToHashSet(StringComparer.Ordinal);

var signInResult = await _microsoftAccountClient.SignInInteractivelyAsync(cancellationToken).ConfigureAwait(false);

var afterAccounts = _microsoftAccountClient.GetAccounts();
await LoadAllAccountsAsync().ConfigureAwait(false);

var candidateIdentifiers = BuildMaterializationCandidates(
    signInResult,
    beforeIdentifiers,
    afterAccounts,
    _microsoftAccountClient.GetDefaultAccountIdentifier());
```

Line by line:

- Capture Microsoft account identifiers before sign-in.
- Start interactive sign-in.
- Read accounts after sign-in.
- Reload Emerald account list from CmlLib plus settings.
- Build a candidate identifier list to find which loaded account corresponds to the new sign-in.

Why candidate matching exists:

- CmlLib/MSAL can return different identifiers depending on account state.
- New account may be found by returned UUID, newly added account, default account, or most recent account.
- The branch tries those in order instead of assuming one field is always correct.

## 9. Ely.by OAuth Sign-In Flow

This is the central new flow.

### OAuth Options

Snippet:

```csharp
internal sealed record ElyByOAuthOptions(
    string ClientId,
    string ClientSecret,
    string RedirectUri,
    string Scope = ElyByOAuthOptions.DefaultScope)
{
    public const string DefaultScope = "account_info offline_access minecraft_server_session";

    public bool IsConfigured
        => !IsPlaceholder(ClientId)
           && !IsPlaceholder(ClientSecret)
           && Uri.TryCreate(RedirectUri, UriKind.Absolute, out _);
}
```

Line by line:

- `ElyByOAuthOptions`: immutable-ish record for Ely OAuth configuration.
- `ClientId`: Ely OAuth app client id.
- `ClientSecret`: Ely OAuth app client secret.
- `RedirectUri`: loopback callback URI.
- `Scope`: defaults to the scopes Emerald needs.
- `account_info`: lets Emerald fetch username/UUID.
- `offline_access`: lets Emerald receive refresh tokens.
- `minecraft_server_session`: makes the token suitable for Minecraft server session use.
- `IsConfigured`: prevents placeholder or invalid values from being used.

### App DI Registration

Snippet with secret redacted here intentionally:

```csharp
private const string ElyByClientId = "emerald1";
private const string ElyByClientSecret = "<redacted>";
private const string ElyByRedirectUri = "http://127.0.0.1:58135/oauth/elyby/";

services.AddSingleton<CoreX.Services.Auth.ElyBy.ElyByOAuthOptions>(_ =>
    new CoreX.Services.Auth.ElyBy.ElyByOAuthOptions(
        ElyByClientId,
        ElyByClientSecret,
        ElyByRedirectUri));
```

Line by line:

- Client id is defined at app composition level.
- Client secret is currently defined there too. This is functional but sensitive.
- Redirect URI is the local callback URI.
- DI registers `ElyByOAuthOptions` as singleton because config is app-wide.
- `ElyByAuthClient` receives these options through DI.

### AccountService Ely Sign-In

Snippet:

```csharp
public async Task SignInElyByAccountAsync(CancellationToken cancellationToken = default)
{
    EnsureElyByAccountPolicyMet("Signing in with Ely.by requires at least one Microsoft account.");
    cancellationToken.ThrowIfCancellationRequested();

    var state = CreateOAuthState();
    var authorizationRequest = _elyByAuthClient.CreateOAuthAuthorizationRequest(state);

    _logger.LogInformation("Starting Ely.by browser sign-in.");
    var authorizationResult = await _elyByOAuthBrowser
        .AuthorizeAsync(authorizationRequest, cancellationToken)
        .ConfigureAwait(false);
    var session = await _elyByAuthClient
        .ExchangeOAuthCodeAsync(authorizationResult.Code, cancellationToken)
        .ConfigureAwait(false);

    await AddOrUpdateElyBySessionAsync(session, cancellationToken).ConfigureAwait(false);
    _logger.LogInformation("Ely.by account '{Name}' signed in through OAuth.", session.Name);
}
```

Line by line:

- `EnsureElyByAccountPolicyMet(...)`: checks the Microsoft-required policy. Currently disabled, but still wired.
- `ThrowIfCancellationRequested()`: cancels before doing OAuth work.
- `CreateOAuthState()`: creates a random anti-CSRF state value.
- `CreateOAuthAuthorizationRequest(state)`: builds the Ely authorization URL and redirect metadata.
- log line: records that browser sign-in is starting.
- `_elyByOAuthBrowser.AuthorizeAsync(...)`: app-layer browser flow opens the browser and waits for callback.
- `authorizationResult.Code`: the OAuth authorization code from Ely.by.
- `_elyByAuthClient.ExchangeOAuthCodeAsync(...)`: trades the code for access/refresh token and account info.
- `AddOrUpdateElyBySessionAsync(...)`: persists the Ely account and updates the observable account list.
- final log: confirms success.

### OAuth State Generation

Snippet:

```csharp
private static string CreateOAuthState()
{
    Span<byte> bytes = stackalloc byte[32];
    RandomNumberGenerator.Fill(bytes);
    return Convert.ToHexString(bytes).ToLowerInvariant();
}
```

Line by line:

- `Span<byte> bytes = stackalloc byte[32]`: creates 32 random bytes on the stack.
- `RandomNumberGenerator.Fill(bytes)`: fills those bytes cryptographically.
- `Convert.ToHexString(bytes)`: converts to hex.
- `.ToLowerInvariant()`: normalizes casing for URL/state comparison.

Why this matters:

- The state prevents accepting random or malicious callbacks.
- The browser callback must include the same state value.

## 10. Ely.by Loopback Browser Callback Flow

The browser implementation lives in the app layer because it uses platform/browser APIs.
CoreX only knows `IElyByOAuthBrowser`.

### Contract

```csharp
internal interface IElyByOAuthBrowser
{
    Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
        ElyByOAuthAuthorizationRequest request,
        CancellationToken cancellationToken = default);
}

internal sealed record ElyByOAuthAuthorizationRequest(
    Uri AuthorizationUri,
    Uri RedirectUri,
    string State);

internal sealed record ElyByOAuthAuthorizationResult(string Code);
```

Line by line:

- `IElyByOAuthBrowser`: abstraction so CoreX does not depend on Uno/WinUI browser details.
- `AuthorizeAsync`: open browser, wait for OAuth result, return code.
- `AuthorizationUri`: Ely URL to open.
- `RedirectUri`: local URI to listen on.
- `State`: state value expected in callback.
- `ElyByOAuthAuthorizationResult`: currently only needs the authorization code.

### Loopback Authorization

Snippet:

```csharp
public async Task<ElyByOAuthAuthorizationResult> AuthorizeAsync(
    ElyByOAuthAuthorizationRequest request,
    CancellationToken cancellationToken = default)
{
    EnsureLoopbackRedirectUri(request.RedirectUri);

    using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
    timeoutSource.CancelAfter(AuthorizationTimeout);

    using var listener = new HttpListener();
    listener.Prefixes.Add(ToListenerPrefix(request.RedirectUri));
    listener.Start();

    var opened = await LaunchBrowserAsync(request.AuthorizationUri).ConfigureAwait(false);
    if (!opened)
        throw new ElyByAuthException("Could not open the Ely.by authorization page in your browser.");
```

Line by line:

- Method receives the request from CoreX.
- `EnsureLoopbackRedirectUri(...)`: validates URI is local loopback HTTP.
- `CreateLinkedTokenSource(...)`: combines user cancel token with timeout token.
- `CancelAfter(AuthorizationTimeout)`: enforces five-minute timeout.
- `new HttpListener()`: creates a local HTTP listener for Ely redirect.
- `Prefixes.Add(...)`: listens on the exact callback prefix.
- `listener.Start()`: begins accepting callbacks.
- `LaunchBrowserAsync(...)`: opens the system browser to Ely OAuth.
- `if (!opened)`: if browser launch failed, throw an Ely auth exception.

Callback loop:

```csharp
while (true)
{
    var context = await listener.GetContextAsync().WaitAsync(timeoutSource.Token).ConfigureAwait(false);
    if (!IsExpectedCallback(request.RedirectUri, context.Request.Url))
    {
        await WriteHtmlResponseAsync(
            context.Response,
            404,
            "Not found",
            "This callback does not belong to the current Ely.by sign-in request.").ConfigureAwait(false);
        continue;
    }
```

Line by line:

- `while (true)`: keep listening until valid callback, error, timeout, or cancel.
- `GetContextAsync()`: waits for an HTTP request to the local listener.
- `WaitAsync(timeoutSource.Token)`: makes listener wait cancelable.
- `IsExpectedCallback(...)`: rejects wrong host/port/path.
- `WriteHtmlResponseAsync(... 404 ...)`: tells the browser this was not the right callback.
- `continue`: keep waiting for the actual callback.

State and error handling:

```csharp
var query = context.Request.QueryString;
var state = query["state"];
if (!string.Equals(state, request.State, StringComparison.Ordinal))
{
    await WriteHtmlResponseAsync(
        context.Response,
        400,
        "Sign-in rejected",
        "The Ely.by sign-in response did not match the original request.").ConfigureAwait(false);
    throw new ElyByAuthException("Ely.by sign-in returned an invalid OAuth state.");
}

var error = query["error"];
if (!string.IsNullOrWhiteSpace(error))
{
    var message = query["error_message"] ?? query["error_description"] ?? error;
    await WriteHtmlResponseAsync(context.Response, 400, "Sign-in cancelled", message).ConfigureAwait(false);
    throw new ElyByAuthException(message);
}
```

Line by line:

- `query`: reads OAuth callback query parameters.
- `state`: extracts returned OAuth state.
- state comparison: protects against mismatched callback.
- failure HTML: browser shows a clear message.
- throw: returns an auth failure to the viewmodel.
- `error`: checks if Ely sent an OAuth error.
- `message`: chooses the best available human-readable error.
- write HTML: browser displays cancellation/failure.
- throw: app handles it as Ely sign-in failure.

Code success handling:

```csharp
var code = query["code"];
if (string.IsNullOrWhiteSpace(code))
{
    await WriteHtmlResponseAsync(
        context.Response,
        400,
        "Sign-in failed",
        "Ely.by did not return an authorization code.").ConfigureAwait(false);
    throw new ElyByAuthException("Ely.by did not return an authorization code.");
}

await WriteHtmlResponseAsync(
    context.Response,
    200,
    "Sign-in complete",
    "You can close this browser tab and return to Emerald.").ConfigureAwait(false);
return new ElyByOAuthAuthorizationResult(code);
```

Line by line:

- `code`: extracts authorization code.
- `if empty`: Ely did not return the expected code.
- failure HTML and exception: surface a clear error.
- success HTML: browser tells user they can return to Emerald.
- return result: gives CoreX the code to exchange for tokens.

Timeout and cleanup:

```csharp
catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
{
    throw new ElyByAuthException("Timed out waiting for Ely.by browser sign-in to complete.");
}
finally
{
    listener.Stop();
}
```

Line by line:

- If the linked token canceled but the user token did not, it was timeout.
- Timeout is reported as Ely auth failure, not user cancel.
- `finally`: always stops the listener.

## 11. Ely.by Token Exchange And Account Info Flow

### Build Authorization URL

Snippet:

```csharp
var parameters = new List<(string Key, string? Value)>
{
    ("client_id", oauthOptions.ClientId),
    ("redirect_uri", oauthOptions.RedirectUri),
    ("response_type", "code"),
    ("scope", oauthOptions.Scope),
    ("state", state)
};

if (!string.IsNullOrWhiteSpace(loginHint))
    parameters.Add(("login_hint", loginHint));

var authorizationUri = new Uri(AccountBaseUri, "oauth2/v1?" + BuildQuery(parameters));
return new ElyByOAuthAuthorizationRequest(authorizationUri, redirectUri, state);
```

Line by line:

- Creates query parameter list.
- `client_id`: identifies Emerald's Ely app.
- `redirect_uri`: must match registered Ely app redirect URI.
- `response_type=code`: requests authorization code flow.
- `scope`: requests account info, refresh token, and Minecraft server session permission.
- `state`: anti-CSRF state.
- optional `login_hint`: can prefill/guide login later.
- `BuildQuery(...)`: URL-encodes the parameters.
- return request: packs URL, redirect URI, and expected state for browser handler.

### Exchange Code

Snippet:

```csharp
var response = await SendOAuthTokenRequestAsync(
        new Dictionary<string, string>
        {
            ["client_id"] = oauthOptions.ClientId,
            ["client_secret"] = oauthOptions.ClientSecret,
            ["redirect_uri"] = oauthOptions.RedirectUri,
            ["grant_type"] = "authorization_code",
            ["code"] = code
        },
        cancellationToken)
    .ConfigureAwait(false);

return await CreateOAuthSessionAsync(response, fallbackRefreshToken: null, cancellationToken).ConfigureAwait(false);
```

Line by line:

- Creates a form-urlencoded token request.
- `client_id`: Ely OAuth app id.
- `client_secret`: Ely OAuth app secret.
- `redirect_uri`: must match the authorization request.
- `grant_type=authorization_code`: tells Ely this is code exchange.
- `code`: one-time authorization code from callback.
- `SendOAuthTokenRequestAsync(...)`: POSTs to Ely token endpoint.
- `CreateOAuthSessionAsync(...)`: turns token response plus account info into Emerald session model.

### Token Request Helper

Snippet:

```csharp
using var content = new FormUrlEncodedContent(parameters);
using var response = await _httpClient.PostAsync(OAuthTokenEndpoint, content, cancellationToken)
    .ConfigureAwait(false);

var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
if (response.IsSuccessStatusCode)
{
    var tokenResponse = JsonSerializer.Deserialize<ElyByOAuthTokenResponse>(body, JsonOptions);
    return tokenResponse ?? throw new ElyByAuthException("Ely.by returned an empty OAuth token response.");
}

var error = TryDeserializeOAuthError(body);
throw new ElyByAuthException(error?.ErrorDescription ?? error?.Error ?? $"Ely.by OAuth token request failed with status {(int)response.StatusCode}.");
```

Line by line:

- `FormUrlEncodedContent`: OAuth token endpoint expects form fields.
- `_httpClient.PostAsync(...)`: sends token request.
- `ReadAsStringAsync(...)`: reads response body for success or error parsing.
- `IsSuccessStatusCode`: only successful HTTP codes are parsed as token response.
- `JsonSerializer.Deserialize`: maps JSON to `ElyByOAuthTokenResponse`.
- null guard: prevents silent empty token response.
- error parse: tries to get OAuth error details.
- throw: surfaces a useful Ely auth exception.

### Create OAuth Session

Snippet:

```csharp
if (string.IsNullOrWhiteSpace(response.AccessToken))
    throw new ElyByAuthException("Ely.by returned an OAuth response without an access token.");

var accountInfo = await GetOAuthAccountInfoAsync(response.AccessToken, cancellationToken).ConfigureAwait(false);
var uuid = NormalizeUuid(accountInfo.UUID);
if (string.IsNullOrWhiteSpace(uuid))
    throw new ElyByAuthException("Ely.by returned account info without a UUID.");

if (string.IsNullOrWhiteSpace(accountInfo.Username))
    throw new ElyByAuthException("Ely.by returned account info without a username.");
```

Line by line:

- access token is mandatory.
- account info is fetched using the access token.
- UUID is normalized by removing hyphens.
- missing UUID is fatal.
- username is mandatory too.

Session construction:

```csharp
var expiresAt = response.ExpiresIn > 0
    ? DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn)
    : (DateTimeOffset?)null;

return new ElyByAuthSession(
    accountInfo.Username,
    uuid,
    response.AccessToken,
    Guid.NewGuid().ToString("N"),
    string.IsNullOrWhiteSpace(response.RefreshToken) ? fallbackRefreshToken : response.RefreshToken,
    expiresAt,
    ElyByAuthFlow.OAuth);
```

Line by line:

- `expiresAt`: stores absolute expiration time if Ely returns `expires_in`.
- `accountInfo.Username`: Minecraft/Ely username.
- `uuid`: normalized player UUID.
- `response.AccessToken`: token used as Minecraft session access token.
- `Guid.NewGuid().ToString("N")`: creates an internal client token because OAuth token response does not provide a Yggdrasil client token.
- refresh token: keeps new refresh token, otherwise preserves old one during refresh.
- `expiresAt`: used later to decide whether to refresh before launch.
- `ElyByAuthFlow.OAuth`: marks this stored account as browser OAuth based.

### Account Info Request

Snippet:

```csharp
using var request = new HttpRequestMessage(HttpMethod.Get, AccountInfoEndpoint);
request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
```

Line by line:

- Creates a GET request to Ely account info endpoint.
- Adds `Authorization: Bearer <access token>`.
- Sends request with cancellation support.

## 12. Account Storage And Loading

Ely accounts are stored separately from `MinecraftAccounts`.

Key:

```csharp
public const string ElyByAccounts = "ElyByAccounts";
```

Stored model:

```csharp
internal sealed class ElyByStoredAccount
{
    public string UniqueId { get; set; } = string.Empty;
    public string Name { get; set; } = string.Empty;
    public string UUID { get; set; } = string.Empty;
    public string AccessToken { get; set; } = string.Empty;
    public string ClientToken { get; set; } = string.Empty;
    public string RefreshToken { get; set; } = string.Empty;
    public DateTimeOffset? AccessTokenExpiresAt { get; set; }
    public ElyByAuthFlow AuthFlow { get; set; } = ElyByAuthFlow.Direct;
    public DateTime LastUsed { get; set; } = DateTime.UtcNow;
}
```

Line by line:

- `UniqueId`: Emerald stable account id, formatted like `elyby:<uuid>`.
- `Name`: display/player name.
- `UUID`: player UUID.
- `AccessToken`: current Ely/Minecraft session token.
- `ClientToken`: local client token used for session construction.
- `RefreshToken`: OAuth refresh token.
- `AccessTokenExpiresAt`: known access token expiry.
- `AuthFlow`: `Direct` or `OAuth`, important for refresh behavior.
- `LastUsed`: account sorting and display metadata.

Loading:

```csharp
var storedElyByAccounts = _elyByAccountStore.GetAccounts()
    .Select(CreateElyByAccount)
    .ToList();
```

Line by line:

- Reads Ely stored account records.
- Converts them into visible `EAccount` objects.
- Adds them to the account list alongside offline and Microsoft accounts.

Creating visible account:

```csharp
private static EAccount CreateElyByAccount(ElyByStoredAccount account)
    => new(
        account.Name,
        AccountType.ElyBy,
        account.UUID,
        account.UniqueId)
    {
        LastUsed = account.LastUsed == default ? DateTime.UtcNow : account.LastUsed,
        ProviderId = AccountProviderIds.ElyBy
    };
```

Line by line:

- Uses stored name.
- Sets type to `ElyBy`.
- Sets UUID.
- Preserves unique id.
- Uses stored last-used value or current time fallback.
- Sets stable provider id.

## 13. Launch-Time Authentication

Launch-time authentication begins in `GameRuntimeService`.

Branch change:

```csharp
var authenticationResult = await _accountService.AuthenticateAccountAsync(account);

var process = await game.BuildProcess(
    game.Version.RealVersion,
    authenticationResult.Session,
    authenticationResult.RuntimeOptions);
```

Line by line:

- Authenticates selected account just before launch.
- Receives `GameAuthenticationResult`, not just `MSession`.
- Sends the CmlLib session to `BuildProcess`.
- Sends provider-specific runtime auth options too.

`GameAuthenticationResult`:

```csharp
public sealed record GameAuthenticationResult(
    MSession Session,
    AccountRuntimeAuthOptions RuntimeOptions)
{
    public GameAuthenticationResult(MSession session)
        : this(session, AccountRuntimeAuthOptions.Empty)
    {
    }
}
```

Line by line:

- `Session`: CmlLib session for launch.
- `RuntimeOptions`: optional extra auth launch data.
- Convenience constructor: providers without extra args can just pass session.
- Default runtime options are empty.

## 14. How authlib-injector Enters The Minecraft Process

Ely.by needs authlib-injector so Minecraft uses Ely's auth/session endpoints.

Ely provider:

```csharp
var javaAgentArgument = await authlibInjectorService.GetJavaAgentArgumentAsync(cancellationToken).ConfigureAwait(false);
var runtimeOptions = new AccountRuntimeAuthOptions([new MArgument(javaAgentArgument)]);
```

Line by line:

- Gets or downloads authlib-injector jar.
- Returns a JVM `-javaagent` argument targeting Ely.
- Wraps it as a CmlLib `MArgument`.
- Packs that into `AccountRuntimeAuthOptions`.

Authlib service:

```csharp
public async Task<string> GetJavaAgentArgumentAsync(CancellationToken cancellationToken = default)
{
    var jarPath = await EnsureJarAsync(cancellationToken).ConfigureAwait(false);
    return $"-javaagent:{jarPath}=ely.by";
}
```

Line by line:

- `EnsureJarAsync`: makes sure jar exists locally.
- returns `-javaagent:<path>=ely.by`.
- That exact string is later appended to CmlLib launch JVM args.

Game process build:

```csharp
if (runtimeAuthOptions?.ExtraJvmArguments.Count > 0)
{
    launchOpt.ExtraJvmArguments = launchOpt.ExtraJvmArguments
        .Concat(runtimeAuthOptions.ExtraJvmArguments)
        .ToArray();
}
```

Line by line:

- Checks whether the provider returned extra JVM auth arguments.
- Takes existing game settings JVM args.
- Concatenates provider JVM args.
- Converts to array because CmlLib launch options expect array-like argument collection.

## 15. Removal And Sign-Out

Removal goes through `AccountService.RemoveAccountAsync`.

Microsoft:

```csharp
if (account.Type == AccountType.Microsoft)
{
    await EnsureInitializedAsync().ConfigureAwait(false);
    await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
    await LoadAllAccountsAsync().ConfigureAwait(false);
    return;
}
```

Line by line:

- Microsoft requires initialized CmlLib login handler.
- Provider signs the Microsoft account out of CmlLib.
- Reloads accounts from CmlLib/settings.
- Returns early because reload handles collection updates.

Ely.by:

```csharp
if (account.Type == AccountType.ElyBy)
{
    await GetAuthenticationProvider(account.Type).RemoveAsync(account).ConfigureAwait(false);
}
```

Line by line:

- Ely provider handles Ely-specific cleanup.
- For OAuth accounts, remote invalidation is skipped because no revoke endpoint is documented in the current implementation.
- Account is removed from `ElyByAccounts` local settings.

## 16. Tests Added By The Branch

Important test coverage in `Emerald.CoreX.Tests/Services/AccountServiceTests.cs`:

- `RequireMicrosoftAccountForOfflineAccounts_IsDisabled`
- `RequireMicrosoftAccountForElyByAccounts_IsDisabled`
- `SignInElyByAccountAsync_WithoutMicrosoftAccount_UsesBrowserOAuth`
- `SignInElyByAccountAsync_CanceledDuringBrowserAuthorization_DoesNotAddAccount`
- `SignInMicrosoftAccountAsync_CanceledDuringInteractiveSignIn_DoesNotMaterializeAccount`
- `SignInElyByAccountAsync_AddsOAuthStoredAccount_AndSelectsWhenNoSelectionExists`
- `AuthenticateAccountAsync_ElyByRefreshesExpiredToken_AndAddsAuthlibJavaAgent`
- `AuthenticateAccountAsync_ElyByOAuthRefreshesExpiredAccessToken_AndAddsAuthlibJavaAgent`

The cancellation tests are especially useful because they prove:

- canceling Ely before callback does not exchange a code,
- canceling Microsoft before completion does not materialize an account,
- canceled flows do not add accounts accidentally.

## 17. Future Provider Checklist

The branch makes future auth providers easier. To add another provider, likely steps are:

1. Add enum value to `AccountType`.
2. Add provider id to `AccountProviderIds`.
3. Add stored account model if the provider needs private token storage.
4. Add account client abstraction for HTTP/OAuth/provider API.
5. Add provider implementation of `IAccountAuthenticationProvider`.
6. Register provider in `AccountService.CreateDefaultAuthenticationProviders`.
7. Add sign-in method to `IAccountService` only if UI needs a custom sign-in flow.
8. Add viewmodel command and UI button.
9. Add tests for sign-in, refresh, launch authentication, removal, and cancellation.

## 18. Risks And Follow-Up Notes

### Secret in source

`ElyByClientSecret` is currently in `App.xaml.cs`. This works but is risky. Better future options:

- local developer secret file,
- environment variable,
- platform credential store,
- server-side token exchange if public distribution needs to hide the secret.

### Microsoft cancellation limitation

`WaitAsync(cancellationToken)` makes Emerald stop waiting. It does not necessarily stop the browser or internal MSAL flow after launch.
The implementation avoids materializing/storing after user cancellation.

### OAuth token storage

Ely OAuth refresh tokens are stored in app settings via `IBaseSettingsService`. That matches the current local persistence style,
but refresh tokens are sensitive.

### authlib-injector download

First Ely launch may need network to download authlib-injector. If that fails, Ely launch auth fails.

### Direct Ely auth still exists

`ElyByAuthClient.AuthenticateAsync(login, password, twoFactorCode)` still exists for compatibility/testing, but the UI now uses OAuth.

## End-To-End Ely.by Flow In One Pass

1. User clicks `Sign in with Ely.by`.
2. XAML invokes `ViewModel.AddElyByAccountCommand`.
3. ViewModel creates cancellation token and sets `IsLoginInProgress`.
4. ViewModel calls `IAccountService.SignInElyByAccountAsync(token)`.
5. AccountService validates Ely policy.
6. AccountService creates OAuth state.
7. Ely client builds authorization URL.
8. Ely loopback browser validates redirect URI.
9. Loopback browser starts `HttpListener`.
10. Loopback browser opens system browser.
11. User signs in through Ely.by.
12. Ely redirects to `http://127.0.0.1:58135/oauth/elyby/?code=...&state=...`.
13. Loopback browser validates callback path and state.
14. Loopback browser returns authorization code.
15. Ely client exchanges code for token.
16. Ely client calls account info endpoint with bearer token.
17. Ely client builds `ElyByAuthSession`.
18. AccountService converts session to `ElyByStoredAccount`.
19. Ely store upserts into `SettingsKeys.ElyByAccounts`.
20. AccountService adds or updates visible `EAccount`.
21. AccountService selects it if no account was selected.
22. ViewModel shows success and ends login state.

## End-To-End Ely.by Launch Flow In One Pass

1. User launches a game.
2. Runtime gets selected account.
3. Runtime calls `AuthenticateAccountAsync`.
4. AccountService chooses Ely provider by `AccountType.ElyBy`.
5. Ely provider finds stored Ely account.
6. If OAuth token is expired or close to expired, provider refreshes it.
7. Provider saves refreshed token data.
8. Provider gets authlib-injector JVM argument.
9. Provider creates CmlLib `MSession`.
10. Provider returns `GameAuthenticationResult(session, runtimeOptions)`.
11. Runtime calls `Game.BuildProcess(version, session, runtimeOptions)`.
12. `Game.BuildProcess` sets `launchOpt.Session`.
13. `Game.BuildProcess` appends authlib-injector JVM argument.
14. CmlLib builds the Minecraft process.
15. Minecraft starts with Ely-compatible authlib behavior.

## End-To-End Cancel Flow In One Pass

1. Login starts.
2. ViewModel creates `_loginCancellationSource`.
3. UI shows `Cancel login`.
4. User clicks Cancel.
5. ViewModel calls `_loginCancellationSource.Cancel()`.
6. Ely loopback `WaitAsync(token)` or Microsoft `WaitAsync(token)` observes cancellation.
7. Operation throws `OperationCanceledException`.
8. ViewModel catches cancellation as a normal user action.
9. ViewModel clears login state.
10. No account is added from the canceled flow.

