### PR TITLE
[BUG-Fix] Fix unknown crash when search for store item (sometimes) in windows platform, fix RAM slider crash

### DIFF
--- a/Emerald/Helpers/Converters/ImageUrlToImageSourceConverter.cs
+++ b/Emerald/Helpers/Converters/ImageUrlToImageSourceConverter.cs
@@ -1,0 +1,22 @@
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Emerald.Helpers.Converters;
+
+public sealed class ImageUrlToImageSourceConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not string url || string.IsNullOrWhiteSpace(url))
+        {
+            return null;
+        }
+
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            ? new BitmapImage(uri)
+            : null;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}

--- a/Emerald/UserControls/MinecraftSettingsUC.xaml
+++ b/Emerald/UserControls/MinecraftSettingsUC.xaml
@@ -97,24 +97,26 @@
             </StackPanel>
           </cn:SettingsExpander.Content>
           <cn:SettingsExpander.Items>
-            <StackPanel
-              Padding="12,12,12,6"
-              Spacing="8">
-              <Slider
-                Minimum="{x:Bind MinRamMb, Mode=OneWay}"
-                Maximum="{x:Bind MaxRamMb, Mode=OneWay}"
-                StepFrequency="64"
-                SmallChange="64"
-                LargeChange="256"
-                Value="{x:Bind RamSliderValue, Mode=TwoWay}" />
-              <TextBlock
-                HorizontalAlignment="Right"
-                Opacity="0.8"
-                Style="{StaticResource CaptionTextBlockStyle}">
-                <Run Text="{x:Bind GameSettings.MaximumRamMb, Mode=OneWay}" />
-                <Run Text=" MB" />
-              </TextBlock>
-            </StackPanel>
+            <cn:SettingsCard
+              HorizontalContentAlignment="Stretch"
+              ContentAlignment="Left">
+              <StackPanel Spacing="8">
+                <Slider
+                  Minimum="{x:Bind MinRamMb, Mode=OneWay}"
+                  Maximum="{x:Bind MaxRamMb, Mode=OneWay}"
+                  StepFrequency="64"
+                  SmallChange="64"
+                  LargeChange="256"
+                  Value="{x:Bind RamSliderValue, Mode=TwoWay}" />
+                <TextBlock
+                  HorizontalAlignment="Right"
+                  Opacity="0.8"
+                  Style="{StaticResource CaptionTextBlockStyle}">
+                  <Run Text="{x:Bind GameSettings.MaximumRamMb, Mode=OneWay}" />
+                  <Run Text=" MB" />
+                </TextBlock>
+              </StackPanel>
+            </cn:SettingsCard>
           </cn:SettingsExpander.Items>
         </cn:SettingsExpander>
         <cn:SettingsExpander
@@ -196,91 +198,93 @@
                   Text="{helpers:Localize KeyName=SelectedJavaPathUnavailable}" />
               </StackPanel>
             </cn:SettingsCard>
-            <StackPanel
-              Padding="12,0"
-              Spacing="12"
+            <cn:SettingsCard
+              HorizontalContentAlignment="Stretch"
+              ContentAlignment="Left"
               Visibility="{x:Bind GameSettings.UseCustomJava, Mode=OneWay, Converter={StaticResource BoolToVis}}">
-              <TextBlock
-                Style="{StaticResource BodyStrongTextBlockStyle}"
-                Text="{helpers:Localize KeyName=DetectedJavaRuntimes}" />
-              <TextBlock
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Opacity="0.8"
-                Text="{helpers:Localize KeyName=DetectedJavaRuntimesDescription}" />
-              <StackPanel
-                Orientation="Horizontal"
-                Spacing="8">
-                <Button
-                  Click="RefreshJavaPaths_OnClick"
-                  Content="{helpers:Localize KeyName=RefreshDetectedJava}"
-                  IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
-                <Button
-                  Click="AddJavaFolder_OnClick"
-                  Content="{helpers:Localize KeyName=AddJavaFolder}"
-                  IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
-                <Button
-                  Click="AddJavaFile_OnClick"
-                  Content="{helpers:Localize KeyName=AddJavaFile}"
-                  IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
-              </StackPanel>
-              <ProgressRing
-                IsActive="{x:Bind IsRefreshingJavaPaths, Mode=OneWay}"
-                Visibility="{x:Bind IsRefreshingJavaPaths, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
-              <TextBlock
-                Visibility="{x:Bind HasNoDetectedJavaOptions, Mode=OneWay, Converter={StaticResource BoolToVis}}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Opacity="0.8"
-                Text="{helpers:Localize KeyName=NoJavaRuntimesFound}" />
-              <ListView
-                ItemsSource="{x:Bind JavaRuntimeOptions, Mode=OneWay}"
-                MaxHeight="320"
-                IsItemClickEnabled="True"
-                ItemClick="JavaRuntimeList_ItemClick"
-                SelectedItem="{x:Bind SelectedJavaRuntimeOption, Mode=OneWay}"
-                SelectionMode="Single">
-                <ListView.ItemTemplate>
-                  <DataTemplate>
-                    <Border
-                      Margin="0,0,0,8"
-                      Padding="10"
-                      BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                      BorderThickness="1"
-                      CornerRadius="8">
-                      <StackPanel Spacing="6">
-                        <StackPanel
-                          Orientation="Horizontal"
-                          Spacing="8">
+              <StackPanel Spacing="12">
+                <TextBlock
+                  Style="{StaticResource BodyStrongTextBlockStyle}"
+                  Text="{helpers:Localize KeyName=DetectedJavaRuntimes}" />
+                <TextBlock
+                  Style="{StaticResource CaptionTextBlockStyle}"
+                  Opacity="0.8"
+                  Text="{helpers:Localize KeyName=DetectedJavaRuntimesDescription}" />
+                <StackPanel
+                  Orientation="Horizontal"
+                  Spacing="8">
+                  <Button
+                    Click="RefreshJavaPaths_OnClick"
+                    Content="{helpers:Localize KeyName=RefreshDetectedJava}"
+                    IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
+                  <Button
+                    Click="AddJavaFolder_OnClick"
+                    Content="{helpers:Localize KeyName=AddJavaFolder}"
+                    IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
+                  <Button
+                    Click="AddJavaFile_OnClick"
+                    Content="{helpers:Localize KeyName=AddJavaFile}"
+                    IsEnabled="{x:Bind CanRefreshJavaPaths, Mode=OneWay}" />
+                </StackPanel>
+                <ProgressRing
+                  IsActive="{x:Bind IsRefreshingJavaPaths, Mode=OneWay}"
+                  Visibility="{x:Bind IsRefreshingJavaPaths, Mode=OneWay, Converter={StaticResource BoolToVis}}" />
+                <TextBlock
+                  Visibility="{x:Bind HasNoDetectedJavaOptions, Mode=OneWay, Converter={StaticResource BoolToVis}}"
+                  Style="{StaticResource CaptionTextBlockStyle}"
+                  Opacity="0.8"
+                  Text="{helpers:Localize KeyName=NoJavaRuntimesFound}" />
+                <ListView
+                  ItemsSource="{x:Bind JavaRuntimeOptions, Mode=OneWay}"
+                  MaxHeight="320"
+                  IsItemClickEnabled="True"
+                  ItemClick="JavaRuntimeList_ItemClick"
+                  SelectedItem="{x:Bind SelectedJavaRuntimeOption, Mode=OneWay}"
+                  SelectionMode="Single">
+                  <ListView.ItemTemplate>
+                    <DataTemplate>
+                      <Border
+                        Margin="0,0,0,8"
+                        Padding="10"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <StackPanel Spacing="6">
+                          <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="8">
+                            <TextBlock
+                              Style="{StaticResource BodyStrongTextBlockStyle}"
+                              Text="{Binding Source}" />
+                            <TextBlock
+                              Visibility="{Binding IsCustomSaved, Converter={StaticResource BoolToVis}}"
+                              Style="{StaticResource CaptionTextBlockStyle}"
+                              Text="{helpers:Localize KeyName=Saved}" />
+                            <TextBlock
+                              Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}"
+                              Style="{StaticResource CaptionTextBlockStyle}"
+                              Text="{helpers:Localize KeyName=Selected}" />
+                          </StackPanel>
                           <TextBlock
-                            Style="{StaticResource BodyStrongTextBlockStyle}"
-                            Text="{Binding Source}" />
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{Binding DisplayPath}"
+                            TextWrapping="WrapWholeWords" />
                           <TextBlock
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="{Binding StatusText}" />
+                          <Button
                             Visibility="{Binding IsCustomSaved, Converter={StaticResource BoolToVis}}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{helpers:Localize KeyName=Saved}" />
-                          <TextBlock
-                            Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}"
-                            Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{helpers:Localize KeyName=Selected}" />
+                            Click="RemoveSavedJavaRuntime_OnClick"
+                            Content="{helpers:Localize KeyName=RemoveSavedJava}"
+                            HorizontalAlignment="Left"
+                            Tag="{Binding}" />
                         </StackPanel>
-                        <TextBlock
-                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                          Text="{Binding DisplayPath}"
-                          TextWrapping="WrapWholeWords" />
-                        <TextBlock
-                          Style="{StaticResource CaptionTextBlockStyle}"
-                          Text="{Binding StatusText}" />
-                        <Button
-                          Visibility="{Binding IsCustomSaved, Converter={StaticResource BoolToVis}}"
-                          Click="RemoveSavedJavaRuntime_OnClick"
-                          Content="{helpers:Localize KeyName=RemoveSavedJava}"
-                          HorizontalAlignment="Left"
-                          Tag="{Binding}" />
-                      </StackPanel>
-                    </Border>
-                  </DataTemplate>
-                </ListView.ItemTemplate>
-              </ListView>
-            </StackPanel>
+                      </Border>
+                    </DataTemplate>
+                  </ListView.ItemTemplate>
+                </ListView>
+              </StackPanel>
+            </cn:SettingsCard>
           </cn:SettingsExpander.Items>
         </cn:SettingsExpander>
         <cn:SettingsExpander

--- a/Emerald/Views/Store/ModrinthStoreBrowsePage.xaml
+++ b/Emerald/Views/Store/ModrinthStoreBrowsePage.xaml
@@ -15,6 +15,7 @@
   <Page.Resources>
     <conv:BoolToVisibility x:Key="BoolToVis" />
     <conv:BoolToVisibility x:Key="InverseBoolToVis" Reversed="True" />
+    <conv:ImageUrlToImageSourceConverter x:Key="ImageUrlToImageSource" />
   </Page.Resources>
 
   <Grid Margin="24,0,24,24" ColumnSpacing="16">
@@ -149,7 +150,9 @@
                     Height="80"
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
                     CornerRadius="12">
-                    <Image Source="{x:Bind IconUrl}" Stretch="UniformToFill" />
+                    <Image
+                      Source="{Binding IconUrl, Converter={StaticResource ImageUrlToImageSource}}"
+                      Stretch="UniformToFill" />
                   </Border>
 
                   <StackPanel Grid.Column="1" Spacing="8">

--- a/Emerald/Views/Store/ModrinthStoreDetailsPage.xaml
+++ b/Emerald/Views/Store/ModrinthStoreDetailsPage.xaml
@@ -12,6 +12,7 @@
   <Page.Resources>
     <conv:BoolToVisibility x:Key="BoolToVis" />
     <conv:BoolToVisibility x:Key="InverseBoolToVis" Reversed="True" />
+    <conv:ImageUrlToImageSourceConverter x:Key="ImageUrlToImageSource" />
     <conv:StringToVisibilityConverter x:Key="StringToVis" />
   </Page.Resources>
 
@@ -95,7 +96,9 @@
             Height="104"
             Background="{ThemeResource LayerFillColorDefaultBrush}"
             CornerRadius="16">
-            <Image Source="{Binding SelectedItem.IconUrl}" Stretch="UniformToFill" />
+            <Image
+              Source="{Binding SelectedItem.IconUrl, Converter={StaticResource ImageUrlToImageSource}}"
+              Stretch="UniformToFill" />
           </Border>
 
           <StackPanel Grid.Column="1" Spacing="8">


### PR DESCRIPTION
Introduce ImageUrlToImageSourceConverter (string URL -> BitmapImage) and register it in Modrinth store pages. 
replace raw StackPanels with cn:SettingsCard wrappers for RAM and Java runtime sections, reorganize Java runtime list template.