### PR TITLE
Make Emerald crash handling terminate reliably and recover on next launch, Fix random crashes on Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -1,0 +1,21 @@
+---
+name: Emerald crash report
+about: Report an Emerald launcher crash
+title: ""
+labels: crash, needs-triage
+assignees: ""
+---
+
+## Crash details
+
+Please paste the sanitized report copied by Emerald below.
+
+PASTE CRASH REPORT HERE
+
+## What happened?
+
+<!-- What were you doing immediately before Emerald closed? -->
+
+## Reproduction steps
+
+<!-- If known, list the smallest set of steps that reproduces the crash. -->

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Emerald/bin/Debug/net9.0-desktop/Emerald.dll",
+      "program": "${workspaceFolder}/Emerald/bin/Debug/net10.0-desktop/Emerald.dll",
       "args": [],
       "launchSettingsProfile": "Emerald (Desktop)",
       "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Emerald/Emerald.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Emerald/Emerald.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/Emerald.CoreX.Tests/CrashHandling/CrashHandlingTests.cs
+++ b/Emerald.CoreX.Tests/CrashHandling/CrashHandlingTests.cs
@@ -1,0 +1,332 @@
+using Emerald.CoreX.CrashHandling;
+using Xunit;
+
+namespace Emerald.CoreX.Tests.CrashHandling;
+
+public sealed class CrashHandlingTests
+{
+    [Fact]
+    public void FileStore_WritesAndReadsOrderedReportWithTextExport()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new FileCrashReportStore(temp.Path);
+        var record = CreateRecord("run-1", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        Assert.True(store.TryWrite(record));
+        Assert.True(File.Exists(record.ReportPath));
+        Assert.True(File.Exists(Path.Combine(store.ReportsPath, record.Id, "report.json")));
+
+        var loaded = Assert.Single(store.GetAll());
+        Assert.Equal(record.Id, loaded.Id);
+        Assert.Contains("=== EMERALD CRASH REPORT ===", File.ReadAllText(record.ReportPath!));
+    }
+
+    [Fact]
+    public void FileStore_AssignsUniqueIdsWhenRecordsUseDefaultIds()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new FileCrashReportStore(temp.Path);
+        var first = CreateRecord("run-1", DateTimeOffset.UtcNow);
+        var second = CreateRecord("run-2", DateTimeOffset.UtcNow.AddSeconds(1));
+        first.Id = string.Empty;
+        second.Id = string.Empty;
+
+        Assert.True(store.TryWrite(first));
+        Assert.True(store.TryWrite(second));
+        Assert.NotEqual(first.Id, second.Id);
+        Assert.Equal(2, store.GetAll().Count);
+    }
+
+    [Fact]
+    public void FileStore_IgnoresDamagedRecords()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new FileCrashReportStore(temp.Path);
+        var damagedDirectory = Path.Combine(store.ReportsPath, "damaged");
+        Directory.CreateDirectory(damagedDirectory);
+        File.WriteAllText(Path.Combine(damagedDirectory, "report.json"), "{");
+
+        Assert.Empty(store.GetAll());
+    }
+
+    [Fact]
+    public void FallbackStore_UsesSecondaryLocationWhenPrimaryCannotBeWritten()
+    {
+        using var temp = new TemporaryDirectory();
+        var primaryPath = System.IO.Path.Combine(temp.Path, "primary");
+        var fallbackPath = System.IO.Path.Combine(temp.Path, "fallback");
+        Directory.CreateDirectory(primaryPath);
+        File.WriteAllText(System.IO.Path.Combine(primaryPath, "crashes"), "not a directory");
+
+        var store = new FallbackCrashReportStore(
+            new FileCrashReportStore(primaryPath),
+            new FileCrashReportStore(fallbackPath));
+        var record = CreateRecord("run-fallback", DateTimeOffset.UtcNow);
+
+        Assert.True(store.TryWriteFatal(record));
+        Assert.StartsWith(fallbackPath, record.ReportPath, StringComparison.Ordinal);
+        Assert.Single(store.GetAll());
+    }
+
+    [Fact]
+    public void FileStore_AcknowledgesAndDeletesReports()
+    {
+        using var temp = new TemporaryDirectory();
+        var store = new FileCrashReportStore(temp.Path);
+        var record = CreateRecord("run-1", DateTimeOffset.UtcNow);
+        store.TryWrite(record);
+
+        Assert.True(store.TryAcknowledge(record.Id));
+        Assert.True(store.Get(record.Id)!.IsAcknowledged);
+        Assert.True(store.TryDelete(record.Id));
+        Assert.Null(store.Get(record.Id));
+    }
+
+    [Fact]
+    public void LifecycleTracker_ReportsPreviousUncleanRunAndEntersRecoveryAfterThreeEarlyFailures()
+    {
+        using var temp = new TemporaryDirectory();
+
+        using (var first = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var start = first.BeginRun();
+            first.MarkNormalStartupAttempted();
+        }
+
+        using (var second = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = second.BeginRun();
+            Assert.NotNull(result.PreviousRun);
+            Assert.Equal(1, result.ConsecutiveEarlyFailures);
+            second.MarkRunReconciled(result.PreviousRun!.RunId);
+            second.MarkNormalStartupAttempted();
+        }
+
+        using (var third = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = third.BeginRun();
+            Assert.Equal(2, result.ConsecutiveEarlyFailures);
+            third.MarkRunReconciled(result.PreviousRun!.RunId);
+            third.MarkNormalStartupAttempted();
+        }
+
+        using (var fourth = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = fourth.BeginRun();
+            Assert.Equal(3, result.ConsecutiveEarlyFailures);
+            Assert.True(result.IsRecoveryMode);
+            fourth.MarkRunReconciled(result.PreviousRun!.RunId);
+            fourth.MarkNormalStartupAttempted();
+        }
+
+        using (var clean = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = clean.BeginRun();
+            clean.MarkRunReconciled(result.PreviousRun!.RunId);
+            clean.MarkStartupComplete();
+            clean.MarkCleanExit();
+        }
+
+        using var next = new FileAppLifecycleTracker(temp.Path);
+        using var afterClean = next.BeginRun();
+        Assert.Equal(0, afterClean.ConsecutiveEarlyFailures);
+        Assert.Null(afterClean.PreviousRun);
+    }
+
+    [Fact]
+    public void LifecycleTracker_PreservesRecoveryModeWhenRecoveryOnlyRunExitsCleanly()
+    {
+        using var temp = new TemporaryDirectory();
+
+        using (var first = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var start = first.BeginRun();
+            first.MarkNormalStartupAttempted();
+        }
+
+        using (var second = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = second.BeginRun();
+            second.MarkRunReconciled(result.PreviousRun!.RunId);
+            second.MarkNormalStartupAttempted();
+        }
+
+        using (var third = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = third.BeginRun();
+            third.MarkRunReconciled(result.PreviousRun!.RunId);
+            third.MarkNormalStartupAttempted();
+        }
+
+        using (var recovery = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = recovery.BeginRun();
+            Assert.True(result.IsRecoveryMode);
+            recovery.MarkRunReconciled(result.PreviousRun!.RunId);
+            recovery.MarkCleanExit();
+        }
+
+        using (var stillInRecovery = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var result = stillInRecovery.BeginRun();
+            Assert.True(result.IsRecoveryMode);
+            Assert.Equal(3, result.ConsecutiveEarlyFailures);
+            stillInRecovery.MarkRunReconciled(result.PreviousRun!.RunId);
+            stillInRecovery.MarkStartupComplete();
+            stillInRecovery.MarkCleanExit();
+        }
+
+        using var afterRecovery = new FileAppLifecycleTracker(temp.Path);
+        using var finalStart = afterRecovery.BeginRun();
+        Assert.False(finalStart.IsRecoveryMode);
+    }
+
+    [Fact]
+    public void LifecycleTracker_DoesNotRetireStaleMarkerBeforeCallerReconcilesIt()
+    {
+        using var temp = new TemporaryDirectory();
+        using (var first = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var start = first.BeginRun();
+            first.MarkNormalStartupAttempted();
+        }
+
+        using var second = new FileAppLifecycleTracker(temp.Path);
+        using var result = second.BeginRun();
+
+        Assert.NotNull(result.PreviousRun);
+        Assert.Contains(result.PreviousRuns, run => !run.Reconciled && run.RunId == result.PreviousRun!.RunId);
+    }
+
+    [Fact]
+    public void LifecycleTracker_CleanShutdownDoesNotCreateAnUnexpectedRun()
+    {
+        using var temp = new TemporaryDirectory();
+        using (var first = new FileAppLifecycleTracker(temp.Path))
+        {
+            using var start = first.BeginRun();
+            first.MarkNormalStartupAttempted();
+            first.MarkStartupComplete();
+            first.MarkCleanExit();
+        }
+
+        using var next = new FileAppLifecycleTracker(temp.Path);
+        using var result = next.BeginRun();
+
+        Assert.Null(result.PreviousRun);
+        Assert.Equal(0, result.ConsecutiveEarlyFailures);
+    }
+
+    [Fact]
+    public void ExceptionInfo_ContainsNestedAndAggregateExceptions()
+    {
+        var exception = new AggregateException(
+            new InvalidOperationException("outer", new ArgumentException("inner")),
+            new ApplicationException("second"));
+
+        var info = CrashExceptionInfo.FromException(exception);
+
+        Assert.Equal(2, info.InnerExceptions.Count);
+        Assert.Single(info.InnerExceptions[0].InnerExceptions);
+        Assert.Contains("outer", info.InnerExceptions[0].Message);
+    }
+
+    [Fact]
+    public void Sanitizer_RemovesSecretsAndUserPaths()
+    {
+        var sanitized = CrashTextSanitizer.Sanitize(
+            "Authorization: Bearer super-secret password=hunter2 /home/alice/Emerald/log.txt");
+
+        Assert.DoesNotContain("super-secret", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("hunter2", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("/home/alice", sanitized, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED]", sanitized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sanitizer_RemovesQuotedJsonCredentialsAndCookieHeaders()
+    {
+        var sanitized = CrashTextSanitizer.Sanitize(
+            "{\"access_token\":\"json-secret\", \"password\": \"json-password\"} Cookie: session-secret");
+
+        Assert.DoesNotContain("json-secret", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("json-password", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("session-secret", sanitized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogTailReader_ResolvesRolledLogWhenBasePathDoesNotExist()
+    {
+        using var temp = new TemporaryDirectory();
+        var rolledPath = System.IO.Path.Combine(temp.Path, "app_20260827.log");
+        File.WriteAllText(rolledPath, "latest log line");
+
+        var tail = CrashLogTailReader.Read(System.IO.Path.Combine(temp.Path, "app_.log"));
+
+        Assert.Contains("latest log line", tail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GitHubComposer_EncodesACompactSummaryAndKeepsFullReportSeparate()
+    {
+        var record = CreateRecord("run-1", DateTimeOffset.UtcNow);
+        var draft = new GitHubCrashIssueComposer("https://github.com/RiversideValley/Emerald").Compose(record);
+
+        Assert.StartsWith("https://github.com/RiversideValley/Emerald/issues/new?", draft.Url, StringComparison.Ordinal);
+        Assert.Contains("template=crash_report.md", draft.Url, StringComparison.Ordinal);
+        Assert.Contains("full sanitized report", draft.Body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("=== EMERALD CRASH REPORT ===", draft.FullReport, StringComparison.Ordinal);
+        Assert.DoesNotContain("Application log tail", draft.Body, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GitHubComposer_CompactsOversizedDraftUrl()
+    {
+        var record = CreateRecord("run-1", DateTimeOffset.UtcNow);
+        record.Source = new string('s', 10_000);
+        record.Exception!.Message = new string('m', 20_000);
+
+        var draft = new GitHubCrashIssueComposer("https://github.com/RiversideValley/Emerald").Compose(record);
+
+        Assert.True(draft.Url.Length <= 2_000);
+        Assert.Contains("paste", draft.Body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("=== EMERALD CRASH REPORT ===", draft.FullReport, StringComparison.Ordinal);
+    }
+
+    private static CrashRecord CreateRecord(string runId, DateTimeOffset occurredUtc)
+        => new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            RunId = runId,
+            OccurredUtc = occurredUtc,
+            Kind = CrashRecordKind.ManagedCrash,
+            Source = "Test",
+            AppVersion = "1.2.3",
+            PackageVersion = "1.2.3.4",
+            BuildChannel = "Release",
+            Platform = "Test",
+            OperatingSystem = "Test OS",
+            Architecture = "X64",
+            Runtime = ".NET",
+            Exception = CrashExceptionInfo.FromException(new InvalidOperationException("test"))
+        };
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"emerald-crash-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/Emerald.CoreX.Tests/CrashHandling/CrashProfileProcessTests.cs
+++ b/Emerald.CoreX.Tests/CrashHandling/CrashProfileProcessTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Emerald.CoreX.CrashHandling;
+using Xunit;
+
+namespace Emerald.CoreX.Tests.CrashHandling;
+
+// Opt in with EMERALD_PROCESS_TEST_APP pointing to the built Debug apphost.
+// These tests launch real windows and deliberately terminate their own processes.
+[CollectionDefinition("Crash app processes", DisableParallelization = true)]
+public sealed class CrashProcessCollection;
+
+[Collection("Crash app processes")]
+public sealed class CrashProfileProcessTests
+{
+    [AppProcessTheory]
+    [InlineData("DesktopHost", "Desktop host")]
+    [InlineData("WinAppStartup", "OnLaunched")]
+    [InlineData("MainPage_Loaded", "MainPage.Loaded")]
+    [InlineData("MainPage_Loaded_BeforeAwait", "MainPage.Loaded")]
+    [InlineData("MainPage_Loaded_AfterAwait", "MainPage.Loaded")]
+    [InlineData("DispatcherCallback", "Uno.NativeDispatcher")]
+    [InlineData("AsyncVoidBeforeAwait", "Uno.NativeDispatcher")]
+    [InlineData("AsyncVoidAfterAwait", "Uno.NativeDispatcher")]
+    [InlineData("WorkerThread", "AppDomain.UnhandledException")]
+    [InlineData("CaptureThenTerminate", "Capture-then-terminate test")]
+    public async Task FatalProfile_RearmsEveryLaunch_PersistsOnce_ThenOpensRecovery(string point, string source)
+    {
+        using var directory = new TestDirectory();
+        var store = new FileCrashReportStore(directory.Path);
+
+        // Same directory on both launches: catches persistent .once marker bugs,
+        // stale-session duplicates and recovery dialogs blocking a crash profile.
+        for (var run = 1; run <= 2; run++)
+        {
+            await using var app = new TestApp(directory.Path, point);
+            await app.WaitForExitAsync();
+            Assert.NotEqual(0, app.ExitCode);
+            Assert.True(app.Saw($"Firing {point}"), app.Output);
+            var reports = store.GetAll();
+            Assert.Equal(run, reports.Count);
+            Assert.All(reports, report =>
+            {
+                Assert.Equal(CrashRecordKind.ManagedCrash, report.Kind);
+                Assert.Equal(source, report.Source);
+                Assert.Equal("System.NotImplementedException", report.Exception?.Type);
+                Assert.Contains("Intentional", report.Exception?.Message ?? string.Empty);
+                Assert.False(string.IsNullOrWhiteSpace(report.Exception?.StackTrace));
+                Assert.False(report.IsAcknowledged);
+                Assert.True(File.Exists(report.ReportPath));
+            });
+            Assert.Equal(run, reports.Select(report => report.RunId).Distinct().Count());
+        }
+
+        var newest = store.GetAll()[0];
+        await using var recovery = new TestApp(directory.Path, string.Empty);
+        await recovery.WaitForCheckpointAsync($"Recovery dialog opened: {newest.Id}");
+        Assert.False(recovery.HasExited, recovery.Output);
+        Assert.False(recovery.Saw("ShellReady"), recovery.Output);
+        Assert.Equal(2, store.GetAll().Count);
+        Assert.False(store.Get(newest.Id)!.IsAcknowledged);
+    }
+
+    [AppProcessTheory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public async Task Recovery_ViewAndContinue_UsesOneDialog_ThenReachesShell(int failedLaunches)
+    {
+        using var directory = new TestDirectory();
+        for (var run = 0; run < failedLaunches; run++)
+        {
+            await using var app = new TestApp(directory.Path, "MainPage_Loaded");
+            await app.WaitForExitAsync();
+            Assert.NotEqual(0, app.ExitCode);
+        }
+
+        var store = new FileCrashReportStore(directory.Path);
+        var report = store.GetAll()[0];
+        await using var recovery = new TestApp(directory.Path, string.Empty, "view-continue");
+        await recovery.WaitForCheckpointAsync("ShellReady");
+        Assert.True(recovery.Saw("Recovery details viewed"), recovery.Output);
+        Assert.Equal(1, recovery.CheckpointCount($"Recovery dialog opened: {report.Id}"));
+        Assert.True(store.Get(report.Id)!.IsAcknowledged);
+        Assert.Equal(failedLaunches, store.GetAll().Count);
+        Assert.False(recovery.HasExited, recovery.Output);
+    }
+
+    [AppProcessTheory]
+    [InlineData("", "ShellReady")]
+    [InlineData("OrdinaryError", "Ordinary error logged")]
+    [InlineData("UnobservedTask", "Unobserved task observed")]
+    public async Task NonFatalStartup_ReachesShellWithoutCrashReport(string point, string checkpoint)
+    {
+        using var directory = new TestDirectory();
+        await using var app = new TestApp(directory.Path, point);
+        await app.WaitForCheckpointAsync(checkpoint);
+        await app.WaitForCheckpointAsync("ShellReady");
+        await Task.Delay(250);
+        Assert.False(app.HasExited, app.Output);
+        Assert.Empty(new FileCrashReportStore(directory.Path).GetAll());
+    }
+
+    [AppProcessFact]
+    public async Task PackagedStyleCommandLineArguments_RequireGate_AndTriggerStartupCrash()
+    {
+        using var directory = new TestDirectory();
+        await using var app = new TestApp(directory.Path, "WinAppStartup", useArguments: true);
+        await app.WaitForExitAsync();
+
+        Assert.NotEqual(0, app.ExitCode);
+        Assert.True(app.Saw("Firing WinAppStartup"), app.Output);
+        var report = Assert.Single(new FileCrashReportStore(directory.Path).GetAll());
+        Assert.Equal(CrashRecordKind.ManagedCrash, report.Kind);
+        Assert.Equal("OnLaunched", report.Source);
+        Assert.Equal("System.NotImplementedException", report.Exception?.Type);
+    }
+
+    private sealed class TestApp : IAsyncDisposable
+    {
+        private readonly Process _process;
+        private readonly ConcurrentQueue<string> _output = new();
+        private readonly ConcurrentDictionary<string, int> _checkpoints = new();
+
+        public TestApp(string root, string point, string recoveryAction = "", bool useArguments = false)
+        {
+            var executable = Environment.GetEnvironmentVariable("EMERALD_PROCESS_TEST_APP")!;
+            Assert.True(File.Exists(executable), $"Build the Debug desktop application first: {executable}");
+            var start = new ProcessStartInfo(executable)
+            {
+                WorkingDirectory = System.IO.Path.GetDirectoryName(executable)!,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            if (useArguments)
+            {
+                // Mirrors the WinAppSDK packaged launch profiles. Keep the
+                // environment disabled to prove the explicit argument gate wins.
+                start.Environment["EMERALD_TEST"] = "0";
+                start.ArgumentList.Add("--emerald-test=1");
+                start.ArgumentList.Add($"--emerald-test-data-root={root}");
+                start.ArgumentList.Add($"--emerald-test-crash={point}");
+                start.ArgumentList.Add("--emerald-test-disable-studio=1");
+            }
+            else
+            {
+                start.Environment["EMERALD_TEST"] = "1";
+                start.Environment["EMERALD_TEST_DATA_ROOT"] = root;
+                start.Environment["EMERALD_TEST_CRASH"] = point;
+                start.Environment["EMERALD_TEST_DISABLE_STUDIO"] = "1";
+                start.Environment["EMERALD_TEST_RECOVERY_ACTION"] = recoveryAction;
+            }
+            _process = new Process { StartInfo = start };
+            _process.OutputDataReceived += ReceiveLine;
+            _process.ErrorDataReceived += ReceiveLine;
+            Assert.True(_process.Start());
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+        }
+
+        public bool HasExited => _process.HasExited;
+        public int ExitCode => _process.ExitCode;
+        public string Output => string.Join(Environment.NewLine, _output);
+        public bool Saw(string checkpoint) => _checkpoints.ContainsKey(checkpoint);
+        public int CheckpointCount(string checkpoint) => _checkpoints.GetValueOrDefault(checkpoint);
+
+        private void ReceiveLine(object sender, DataReceivedEventArgs args)
+        {
+            if (args.Data is not { } line) return;
+            const string prefix = "[EMERALD TEST] ";
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                _checkpoints.AddOrUpdate(line[prefix.Length..], 1, (_, count) => count + 1);
+            }
+            _output.Enqueue(line);
+            while (_output.Count > 80) _output.TryDequeue(out _);
+        }
+
+        public async Task WaitForExitAsync()
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try { await _process.WaitForExitAsync(timeout.Token); }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"Fault did not terminate the app within 30 seconds.\n{Output}");
+            }
+        }
+
+        public async Task WaitForCheckpointAsync(string checkpoint)
+        {
+            var elapsed = Stopwatch.StartNew();
+            while (!Saw(checkpoint) && !HasExited && elapsed.Elapsed < TimeSpan.FromSeconds(30))
+            {
+                await Task.Delay(50);
+            }
+            Assert.True(Saw(checkpoint), $"Did not reach '{checkpoint}'.\n{Output}");
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!HasExited)
+            {
+                // Only the owned, isolated test process is terminated for cleanup.
+                _process.Kill(entireProcessTree: true);
+            }
+            await _process.WaitForExitAsync();
+            _process.Dispose();
+        }
+    }
+
+    private sealed class TestDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "emerald-process-" + Guid.NewGuid().ToString("N"));
+        public TestDirectory() => Directory.CreateDirectory(Path);
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}
+
+public sealed class AppProcessTheoryAttribute : TheoryAttribute
+{
+    public AppProcessTheoryAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EMERALD_PROCESS_TEST_APP")))
+        {
+            Skip = "Set EMERALD_PROCESS_TEST_APP to the Debug desktop apphost to run real application crash tests.";
+        }
+    }
+}
+
+public sealed class AppProcessFactAttribute : FactAttribute
+{
+    public AppProcessFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("EMERALD_PROCESS_TEST_APP")))
+        {
+            Skip = "Set EMERALD_PROCESS_TEST_APP to the Debug desktop apphost to run real application crash tests.";
+        }
+    }
+}

--- a/Emerald.CoreX.Tests/CrashHandling/CrashProfileProcessTests.cs
+++ b/Emerald.CoreX.Tests/CrashHandling/CrashProfileProcessTests.cs
@@ -61,6 +61,33 @@ public sealed class CrashProfileProcessTests
         Assert.False(store.Get(newest.Id)!.IsAcknowledged);
     }
 
+    [AppProcessFact]
+    public async Task UnoApplicationUnhandled_CallbackCapturesOnce_ThenOpensRecovery()
+    {
+        using var directory = new TestDirectory();
+        await using var app = new TestApp(directory.Path, "UnoApplicationUnhandled");
+
+        await app.WaitForExitAsync();
+
+        Assert.NotEqual(0, app.ExitCode);
+        Assert.True(app.Saw("Firing UnoApplicationUnhandled"), app.Output);
+        Assert.True(app.Saw("Uno Application.UnhandledException observed"), app.Output);
+
+        var store = new FileCrashReportStore(directory.Path);
+        var report = Assert.Single(store.GetAll());
+        Assert.Equal(CrashRecordKind.ManagedCrash, report.Kind);
+        Assert.Equal("Uno.Application.UnhandledException", report.Source);
+        Assert.Equal("System.NotImplementedException", report.Exception?.Type);
+        Assert.Contains("Intentional", report.Exception?.Message ?? string.Empty);
+        Assert.False(report.IsAcknowledged);
+
+        await using var recovery = new TestApp(directory.Path, string.Empty);
+        await recovery.WaitForCheckpointAsync($"Recovery dialog opened: {report.Id}");
+        Assert.False(recovery.HasExited, recovery.Output);
+        Assert.False(recovery.Saw("ShellReady"), recovery.Output);
+        Assert.False(store.Get(report.Id)!.IsAcknowledged);
+    }
+
     [AppProcessTheory]
     [InlineData(1)]
     [InlineData(3)]

--- a/Emerald.CoreX/CrashHandling/CrashLifecycleTracker.cs
+++ b/Emerald.CoreX/CrashHandling/CrashLifecycleTracker.cs
@@ -1,0 +1,423 @@
+using System.Text.Json;
+
+namespace Emerald.CoreX.CrashHandling;
+
+public interface IAppLifecycleTracker : IDisposable
+{
+    string CurrentRunId { get; }
+    LifecycleStartResult BeginRun();
+    void MarkRunReconciled(string runId);
+    void MarkNormalStartupAttempted();
+    void MarkStartupComplete();
+    void MarkFatalFailure();
+    void MarkCleanExit();
+}
+
+public sealed class LifecycleStartResult : IDisposable
+{
+    private IDisposable? _reconciliationLease;
+
+    public LifecycleRunState? PreviousRun { get; init; }
+    public IReadOnlyList<LifecycleRunState> PreviousRuns { get; init; } = [];
+    public int ConsecutiveEarlyFailures { get; init; }
+    public bool IsRecoveryMode => ConsecutiveEarlyFailures >= 3;
+
+    internal void AttachReconciliationLease(IDisposable? lease)
+        => _reconciliationLease = lease;
+
+    public void Dispose()
+        => Interlocked.Exchange(ref _reconciliationLease, null)?.Dispose();
+}
+
+public sealed class LifecycleRunState
+{
+    public string RunId { get; set; } = string.Empty;
+    public DateTimeOffset StartedUtc { get; set; }
+    public DateTimeOffset LastHeartbeatUtc { get; set; }
+    public bool NormalStartupAttempted { get; set; }
+    public bool StartupCompleted { get; set; }
+    public bool FatalFailure { get; set; }
+    public bool CleanShutdown { get; set; }
+    public bool Reconciled { get; set; }
+    public bool RecoveryOnlySession { get; set; }
+    public int ConsecutiveEarlyFailures { get; set; }
+    public int OwnerProcessId { get; set; }
+    public string AppVersion { get; set; } = string.Empty;
+    public string PackageVersion { get; set; } = string.Empty;
+    public string BuildChannel { get; set; } = string.Empty;
+    public string ReleaseTag { get; set; } = string.Empty;
+    public string CommitSha { get; set; } = string.Empty;
+    public string BuildTimestampUtc { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public string OperatingSystem { get; set; } = string.Empty;
+    public string Architecture { get; set; } = string.Empty;
+    public string Runtime { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Uses one marker per run. This prevents a second Emerald instance from overwriting
+/// the first instance's state and keeps stale-run reconciliation idempotent.
+/// </summary>
+public sealed class FileAppLifecycleTracker : IAppLifecycleTracker
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly object _gate = new();
+    private readonly string _sessionsPath;
+    private readonly string _legacyMarkerPath;
+    private readonly CrashEnvironment? _environment;
+    private Timer? _heartbeatTimer;
+    private FileStream? _ownershipStream;
+    private FileStream? _reconciliationLease;
+    private LifecycleRunState? _currentRun;
+
+    public FileAppLifecycleTracker(string localDataPath, CrashEnvironment? environment = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localDataPath);
+        _sessionsPath = Path.Combine(localDataPath, "crashes", "sessions");
+        _legacyMarkerPath = Path.Combine(localDataPath, "crashes", "lifecycle.json");
+        _environment = environment;
+    }
+
+    public string CurrentRunId => _currentRun?.RunId ?? string.Empty;
+
+    public LifecycleStartResult BeginRun()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is not null)
+            {
+                return BuildStartResult(null, [], _currentRun.ConsecutiveEarlyFailures);
+            }
+
+            FileStream? reconciliationLock = AcquireReconciliationLock();
+            var previousRuns = ReadUnreconciledRuns();
+            var previous = previousRuns
+                .OrderByDescending(run => run.LastHeartbeatUtc)
+                .FirstOrDefault();
+            var earlyFailures = CalculateEarlyFailures(previous);
+
+            var runId = Guid.NewGuid().ToString("N");
+            _currentRun = new LifecycleRunState
+            {
+                RunId = runId,
+                StartedUtc = DateTimeOffset.UtcNow,
+                LastHeartbeatUtc = DateTimeOffset.UtcNow,
+                ConsecutiveEarlyFailures = earlyFailures,
+                RecoveryOnlySession = earlyFailures >= 3,
+                OwnerProcessId = Environment.ProcessId,
+                AppVersion = _environment?.AppVersion ?? string.Empty,
+                PackageVersion = _environment?.PackageVersion ?? string.Empty,
+                BuildChannel = _environment?.BuildChannel ?? string.Empty,
+                ReleaseTag = _environment?.ReleaseTag ?? string.Empty,
+                CommitSha = _environment?.CommitSha ?? string.Empty,
+                BuildTimestampUtc = _environment?.BuildTimestampUtc ?? string.Empty,
+                Platform = _environment?.Platform ?? string.Empty,
+                OperatingSystem = _environment?.OperatingSystem ?? string.Empty,
+                Architecture = _environment?.Architecture ?? string.Empty,
+                Runtime = _environment?.Runtime ?? string.Empty
+            };
+
+            AcquireOwnership(runId);
+            TryWrite(_currentRun);
+
+            _heartbeatTimer = new Timer(_ => Heartbeat(), null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
+
+            if (previousRuns.Count == 0)
+            {
+                reconciliationLock?.Dispose();
+                reconciliationLock = null;
+            }
+            else
+            {
+                _reconciliationLease = reconciliationLock;
+            }
+
+            var result = BuildStartResult(previous, previousRuns, earlyFailures);
+            result.AttachReconciliationLease(reconciliationLock);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Retires a previous run only after the caller has persisted any recovery
+    /// evidence for it. Keeping this separate from BeginRun prevents a failed
+    /// report write from silently losing the stale-session signal.
+    /// </summary>
+    public void MarkRunReconciled(string runId)
+    {
+        if (string.IsNullOrWhiteSpace(runId))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            var sessionPath = Path.Combine(_sessionsPath, $"{runId}.json");
+            var state = TryRead(sessionPath);
+            if (state is not null)
+            {
+                state.Reconciled = true;
+                TryWriteAt(sessionPath, state);
+            }
+
+            var legacy = TryRead(_legacyMarkerPath);
+            if (legacy is not null && string.Equals(legacy.RunId, runId, StringComparison.Ordinal))
+            {
+                legacy.Reconciled = true;
+                TryWriteAt(_legacyMarkerPath, legacy);
+            }
+        }
+    }
+
+    public void MarkNormalStartupAttempted()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is null || _currentRun.NormalStartupAttempted)
+            {
+                return;
+            }
+
+            _currentRun.NormalStartupAttempted = true;
+            Heartbeat();
+        }
+    }
+
+    public void MarkStartupComplete()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is null || _currentRun.FatalFailure)
+            {
+                return;
+            }
+
+            _currentRun.NormalStartupAttempted = true;
+            _currentRun.StartupCompleted = true;
+            _currentRun.ConsecutiveEarlyFailures = 0;
+            _currentRun.RecoveryOnlySession = false;
+            Heartbeat();
+        }
+    }
+
+    public void MarkFatalFailure()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is null || _currentRun.FatalFailure)
+            {
+                return;
+            }
+
+            _currentRun.FatalFailure = true;
+            _currentRun.CleanShutdown = false;
+            TryWrite(_currentRun);
+        }
+    }
+
+    public void MarkCleanExit()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is null || _currentRun.FatalFailure)
+            {
+                return;
+            }
+
+            _currentRun.CleanShutdown = true;
+            _currentRun.LastHeartbeatUtc = DateTimeOffset.UtcNow;
+            if (TryWrite(_currentRun))
+            {
+                _heartbeatTimer?.Dispose();
+                _heartbeatTimer = null;
+                ReleaseOwnership();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _heartbeatTimer?.Dispose();
+            _heartbeatTimer = null;
+            _reconciliationLease?.Dispose();
+            _reconciliationLease = null;
+            ReleaseOwnership();
+        }
+    }
+
+    private static int CalculateEarlyFailures(LifecycleRunState? previous)
+    {
+        if (previous is null)
+        {
+            return 0;
+        }
+
+        if (previous.RecoveryOnlySession && !previous.NormalStartupAttempted)
+        {
+            return previous.ConsecutiveEarlyFailures;
+        }
+
+        return previous.NormalStartupAttempted && !previous.StartupCompleted
+            ? previous.ConsecutiveEarlyFailures + 1
+            : 0;
+    }
+
+    private LifecycleStartResult BuildStartResult(
+        LifecycleRunState? previous,
+        IReadOnlyList<LifecycleRunState> previousRuns,
+        int earlyFailures)
+        => new()
+        {
+            PreviousRun = previous,
+            PreviousRuns = previousRuns,
+            ConsecutiveEarlyFailures = earlyFailures
+        };
+
+    private List<LifecycleRunState> ReadUnreconciledRuns()
+    {
+        var runs = new List<LifecycleRunState>();
+        try
+        {
+            if (Directory.Exists(_sessionsPath))
+            {
+                foreach (var path in Directory.EnumerateFiles(_sessionsPath, "*.json"))
+                {
+                    var state = TryRead(path);
+                    if (state is not null
+                        && !state.Reconciled
+                        && (!state.CleanShutdown || (state.RecoveryOnlySession && !state.StartupCompleted))
+                        && CanAcquireStaleOwnership(state.RunId))
+                    {
+                        runs.Add(state);
+                    }
+                }
+            }
+
+            // One-time compatibility read for the previous single-marker format.
+            var legacy = TryRead(_legacyMarkerPath);
+            if (legacy is not null
+                && !legacy.Reconciled
+                && (!legacy.CleanShutdown || (legacy.RecoveryOnlySession && !legacy.StartupCompleted))
+                && !runs.Any(run => run.RunId == legacy.RunId))
+            {
+                runs.Add(legacy);
+            }
+        }
+        catch
+        {
+        }
+
+        return runs;
+    }
+
+    private void AcquireOwnership(string runId)
+    {
+        try
+        {
+            Directory.CreateDirectory(_sessionsPath);
+            var ownershipPath = Path.Combine(_sessionsPath, $"{runId}.lock");
+            _ownershipStream = new FileStream(ownershipPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch
+        {
+            _ownershipStream = null;
+        }
+    }
+
+    private FileStream? AcquireReconciliationLock()
+    {
+        try
+        {
+            Directory.CreateDirectory(_sessionsPath);
+            var lockPath = Path.Combine(_sessionsPath, "reconcile.lock");
+            for (var attempt = 0; attempt < 100; attempt++)
+            {
+                try
+                {
+                    return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(20);
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    private bool CanAcquireStaleOwnership(string runId)
+    {
+        try
+        {
+            var lockPath = Path.Combine(_sessionsPath, $"{runId}.lock");
+            if (!File.Exists(lockPath))
+            {
+                return true;
+            }
+
+            using var probe = new FileStream(lockPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void ReleaseOwnership()
+    {
+        _ownershipStream?.Dispose();
+        _ownershipStream = null;
+    }
+
+    private void Heartbeat()
+    {
+        lock (_gate)
+        {
+            if (_currentRun is null || _currentRun.CleanShutdown || _currentRun.FatalFailure)
+            {
+                return;
+            }
+
+            _currentRun.LastHeartbeatUtc = DateTimeOffset.UtcNow;
+            TryWrite(_currentRun);
+        }
+    }
+
+    private LifecycleRunState? TryRead(string path)
+    {
+        try
+        {
+            return File.Exists(path)
+                ? JsonSerializer.Deserialize<LifecycleRunState>(File.ReadAllText(path), JsonOptions)
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private bool TryWrite(LifecycleRunState state)
+        => TryWriteAt(Path.Combine(_sessionsPath, $"{state.RunId}.json"), state);
+
+    private static bool TryWriteAt(string path, LifecycleRunState state)
+    {
+        try
+        {
+            AtomicFile.WriteText(path, JsonSerializer.Serialize(state, JsonOptions));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Emerald.CoreX/CrashHandling/CrashLifecycleTracker.cs
+++ b/Emerald.CoreX/CrashHandling/CrashLifecycleTracker.cs
@@ -278,40 +278,48 @@ public sealed class FileAppLifecycleTracker : IAppLifecycleTracker
 
     private List<LifecycleRunState> ReadUnreconciledRuns()
     {
-        var runs = new List<LifecycleRunState>();
         try
         {
-            if (Directory.Exists(_sessionsPath))
-            {
-                foreach (var path in Directory.EnumerateFiles(_sessionsPath, "*.json"))
-                {
-                    var state = TryRead(path);
-                    if (state is not null
-                        && !state.Reconciled
-                        && (!state.CleanShutdown || (state.RecoveryOnlySession && !state.StartupCompleted))
-                        && CanAcquireStaleOwnership(state.RunId))
-                    {
-                        runs.Add(state);
-                    }
-                }
-            }
-
-            // One-time compatibility read for the previous single-marker format.
-            var legacy = TryRead(_legacyMarkerPath);
-            if (legacy is not null
-                && !legacy.Reconciled
-                && (!legacy.CleanShutdown || (legacy.RecoveryOnlySession && !legacy.StartupCompleted))
-                && !runs.Any(run => run.RunId == legacy.RunId))
-            {
-                runs.Add(legacy);
-            }
+            var runs = ReadSessionRuns();
+            AddLegacyRun(runs);
+            return runs;
         }
         catch
         {
+            return [];
+        }
+    }
+
+    private List<LifecycleRunState> ReadSessionRuns()
+    {
+        var runs = new List<LifecycleRunState>();
+        if (!Directory.Exists(_sessionsPath)) return runs;
+
+        foreach (var path in Directory.EnumerateFiles(_sessionsPath, "*.json"))
+        {
+            var state = TryRead(path);
+            if (state is not null && IsUnreconciledRun(state) && CanAcquireStaleOwnership(state.RunId))
+            {
+                runs.Add(state);
+            }
         }
 
         return runs;
     }
+
+    private void AddLegacyRun(List<LifecycleRunState> runs)
+    {
+        // One-time compatibility read for the previous single-marker format.
+        var legacy = TryRead(_legacyMarkerPath);
+        if (legacy is not null && IsUnreconciledRun(legacy) && !runs.Any(run => run.RunId == legacy.RunId))
+        {
+            runs.Add(legacy);
+        }
+    }
+
+    private static bool IsUnreconciledRun(LifecycleRunState state)
+        => !state.Reconciled
+            && (!state.CleanShutdown || (state.RecoveryOnlySession && !state.StartupCompleted));
 
     private void AcquireOwnership(string runId)
     {

--- a/Emerald.CoreX/CrashHandling/CrashRecord.cs
+++ b/Emerald.CoreX/CrashHandling/CrashRecord.cs
@@ -1,0 +1,128 @@
+using System.Text.Json.Serialization;
+
+namespace Emerald.CoreX.CrashHandling;
+
+public enum CrashRecordKind
+{
+    ManagedCrash,
+    UnexpectedShutdown
+}
+
+public sealed class CrashRecord
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string RunId { get; set; } = string.Empty;
+    public DateTimeOffset OccurredUtc { get; set; } = DateTimeOffset.UtcNow;
+    public CrashRecordKind Kind { get; set; }
+    public string Source { get; set; } = string.Empty;
+
+    public string AppVersion { get; set; } = string.Empty;
+    public string PackageVersion { get; set; } = string.Empty;
+    public string BuildChannel { get; set; } = string.Empty;
+    public string ReleaseTag { get; set; } = string.Empty;
+    public string CommitSha { get; set; } = string.Empty;
+    public string BuildTimestampUtc { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public string OperatingSystem { get; set; } = string.Empty;
+    public string Architecture { get; set; } = string.Empty;
+    public string Runtime { get; set; } = string.Empty;
+
+    public CrashExceptionInfo? Exception { get; set; }
+    public string ApplicationLogTail { get; set; } = string.Empty;
+    public string NativeDiagnosticsStatus { get; set; } = "Unavailable";
+    public string? NativeDiagnosticsPath { get; set; }
+    public DateTimeOffset? AcknowledgedUtc { get; set; }
+    public string? ReportPath { get; set; }
+
+    [JsonIgnore]
+    public bool IsAcknowledged => AcknowledgedUtc.HasValue;
+
+    public static CrashRecord CreateUnexpectedShutdown(
+        LifecycleRunState previousRun,
+        CrashEnvironment environment,
+        string applicationLogTail,
+        string nativeDiagnosticsStatus = "Unavailable",
+        string? nativeDiagnosticsPath = null)
+        => new()
+        {
+            RunId = previousRun.RunId,
+            OccurredUtc = previousRun.LastHeartbeatUtc == default
+                ? previousRun.StartedUtc
+                : previousRun.LastHeartbeatUtc,
+            Kind = CrashRecordKind.UnexpectedShutdown,
+            Source = "Lifecycle marker",
+            AppVersion = FirstValue(previousRun.AppVersion, environment.AppVersion),
+            PackageVersion = FirstValue(previousRun.PackageVersion, environment.PackageVersion),
+            BuildChannel = FirstValue(previousRun.BuildChannel, environment.BuildChannel),
+            ReleaseTag = FirstValue(previousRun.ReleaseTag, environment.ReleaseTag),
+            CommitSha = FirstValue(previousRun.CommitSha, environment.CommitSha),
+            BuildTimestampUtc = FirstValue(previousRun.BuildTimestampUtc, environment.BuildTimestampUtc),
+            Platform = FirstValue(previousRun.Platform, environment.Platform),
+            OperatingSystem = FirstValue(previousRun.OperatingSystem, environment.OperatingSystem),
+            Architecture = FirstValue(previousRun.Architecture, environment.Architecture),
+            Runtime = FirstValue(previousRun.Runtime, environment.Runtime),
+            ApplicationLogTail = applicationLogTail,
+            NativeDiagnosticsStatus = nativeDiagnosticsStatus,
+            NativeDiagnosticsPath = nativeDiagnosticsPath
+        };
+
+    private static string FirstValue(string value, string fallback)
+        => string.IsNullOrWhiteSpace(value) ? fallback : value;
+}
+
+public sealed class CrashExceptionInfo
+{
+    public string Type { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public int? HResult { get; set; }
+    public string StackTrace { get; set; } = string.Empty;
+    public List<CrashExceptionInfo> InnerExceptions { get; set; } = [];
+
+    public static CrashExceptionInfo FromException(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return FromException(exception, new HashSet<Exception>(ReferenceEqualityComparer.Instance), 0);
+    }
+
+    private static CrashExceptionInfo FromException(Exception exception, HashSet<Exception> visited, int depth)
+    {
+        var result = new CrashExceptionInfo
+        {
+            Type = exception.GetType().FullName ?? exception.GetType().Name,
+            Message = CrashTextSanitizer.Sanitize(exception.Message, 16_384),
+            HResult = exception.HResult,
+            StackTrace = CrashTextSanitizer.Sanitize(exception.StackTrace, 32_768)
+        };
+
+        if (depth >= 32 || !visited.Add(exception))
+        {
+            return result;
+        }
+
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.InnerExceptions)
+            {
+                result.InnerExceptions.Add(FromException(inner, visited, depth + 1));
+            }
+        }
+        else if (exception.InnerException is not null)
+        {
+            result.InnerExceptions.Add(FromException(exception.InnerException, visited, depth + 1));
+        }
+
+        return result;
+    }
+}
+
+public sealed record CrashEnvironment(
+    string AppVersion,
+    string PackageVersion,
+    string BuildChannel,
+    string ReleaseTag,
+    string CommitSha,
+    string BuildTimestampUtc,
+    string Platform,
+    string OperatingSystem,
+    string Architecture,
+    string Runtime);

--- a/Emerald.CoreX/CrashHandling/CrashReportStore.cs
+++ b/Emerald.CoreX/CrashHandling/CrashReportStore.cs
@@ -1,0 +1,415 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Emerald.CoreX.CrashHandling;
+
+public interface ICrashReportStore
+{
+    string ReportsPath { get; }
+
+    bool TryWrite(CrashRecord record);
+    bool TryWriteFatal(CrashRecord record);
+    IReadOnlyList<CrashRecord> GetAll();
+    CrashRecord? Get(string id);
+    bool HasReportForRun(string runId);
+    bool TryAcknowledge(string id);
+    bool TryDelete(string id);
+    int DeleteAll();
+}
+
+public sealed class FileCrashReportStore : ICrashReportStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private readonly object _gate = new();
+
+    public FileCrashReportStore(string localDataPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localDataPath);
+        ReportsPath = Path.Combine(localDataPath, "crashes", "reports");
+    }
+
+    public string ReportsPath { get; }
+
+    public bool TryWrite(CrashRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        lock (_gate)
+        {
+            try
+            {
+                return TryWriteCore(record);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fatal paths must not wait behind a history operation that may be holding the
+    /// normal store lock. Each report has a unique directory, so this write is safe
+    /// to perform without that lock.
+    /// </summary>
+    public bool TryWriteFatal(CrashRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        try
+        {
+            return TryWriteCore(record);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool TryWriteCore(CrashRecord record)
+    {
+        Directory.CreateDirectory(ReportsPath);
+        record.Id = NormalizeId(record.Id);
+
+        var reportDirectory = Path.Combine(ReportsPath, record.Id);
+        Directory.CreateDirectory(reportDirectory);
+
+        var jsonPath = Path.Combine(reportDirectory, "report.json");
+        var textPath = Path.Combine(reportDirectory, "report.txt");
+        record.ReportPath = textPath;
+
+        AtomicFile.WriteText(jsonPath, JsonSerializer.Serialize(record, JsonOptions));
+        try
+        {
+            AtomicFile.WriteText(textPath, CrashReportFormatter.ToText(record));
+        }
+        catch
+        {
+            // The JSON record is still useful when the human-readable export fails.
+        }
+
+        return true;
+    }
+
+    public IReadOnlyList<CrashRecord> GetAll()
+    {
+        lock (_gate)
+        {
+            if (!Directory.Exists(ReportsPath))
+            {
+                return [];
+            }
+
+            var records = new List<CrashRecord>();
+            IEnumerable<string> reportPaths;
+            try
+            {
+                reportPaths = Directory
+                    .EnumerateFiles(ReportsPath, "report.json", SearchOption.AllDirectories)
+                    .ToArray();
+            }
+            catch
+            {
+                return [];
+            }
+
+            foreach (var path in reportPaths)
+            {
+                try
+                {
+                    var record = JsonSerializer.Deserialize<CrashRecord>(File.ReadAllText(path), JsonOptions);
+                    if (record is null)
+                    {
+                        continue;
+                    }
+
+                    record.ReportPath ??= Path.Combine(Path.GetDirectoryName(path) ?? ReportsPath, "report.txt");
+                    records.Add(record);
+                }
+                catch
+                {
+                    // A partially-written or manually damaged report must not break the history page.
+                }
+            }
+
+            return records
+                .OrderByDescending(record => record.OccurredUtc)
+                .ThenByDescending(record => record.Id, StringComparer.Ordinal)
+                .ToArray();
+        }
+    }
+
+    public CrashRecord? Get(string id)
+        => GetAll().FirstOrDefault(record => string.Equals(record.Id, id, StringComparison.Ordinal));
+
+    public bool HasReportForRun(string runId)
+        => !string.IsNullOrWhiteSpace(runId)
+           && GetAll().Any(record => string.Equals(record.RunId, runId, StringComparison.Ordinal));
+
+    public bool TryAcknowledge(string id)
+    {
+        lock (_gate)
+        {
+            var record = Get(id);
+            if (record is null)
+            {
+                return false;
+            }
+
+            record.AcknowledgedUtc ??= DateTimeOffset.UtcNow;
+            return TryWrite(record);
+        }
+    }
+
+    public bool TryDelete(string id)
+    {
+        lock (_gate)
+        {
+            try
+            {
+                var directory = Path.Combine(ReportsPath, NormalizeId(id));
+                if (!Directory.Exists(directory))
+                {
+                    return false;
+                }
+
+                Directory.Delete(directory, recursive: true);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    public int DeleteAll()
+    {
+        lock (_gate)
+        {
+            var count = 0;
+            foreach (var record in GetAll())
+            {
+                if (TryDelete(record.Id))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+
+    private static string NormalizeId(string? id)
+    {
+        if (!string.IsNullOrWhiteSpace(id)
+            && string.Equals(Path.GetFileName(id), id, StringComparison.Ordinal)
+            && id.All(character => char.IsLetterOrDigit(character) || character is '-' or '_'))
+        {
+            return id;
+        }
+
+        return Guid.NewGuid().ToString("N");
+    }
+}
+
+/// <summary>
+/// Keeps crash capture available when the preferred per-user location becomes
+/// unwritable after startup (for example, a removed profile directory or a
+/// deployment-specific storage restriction). Normal history operations read both
+/// locations and preserve the report's actual path.
+/// </summary>
+public sealed class FallbackCrashReportStore : ICrashReportStore
+{
+    private readonly IReadOnlyList<ICrashReportStore> _stores;
+
+    public FallbackCrashReportStore(params ICrashReportStore[] stores)
+    {
+        if (stores is null || stores.Length == 0)
+        {
+            throw new ArgumentException("At least one crash report store is required.", nameof(stores));
+        }
+
+        _stores = stores
+            .Where(store => store is not null)
+            .GroupBy(store => store.ReportsPath, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+        if (_stores.Count == 0)
+        {
+            throw new ArgumentException("At least one crash report store is required.", nameof(stores));
+        }
+    }
+
+    public string ReportsPath => _stores[0].ReportsPath;
+
+    public bool TryWrite(CrashRecord record)
+        => TryWrite(store => store.TryWrite(record));
+
+    public bool TryWriteFatal(CrashRecord record)
+        => TryWrite(store => store.TryWriteFatal(record));
+
+    public IReadOnlyList<CrashRecord> GetAll()
+        => _stores
+            .SelectMany(SafeGetAll)
+            .GroupBy(record => record.Id, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .OrderByDescending(record => record.OccurredUtc)
+            .ThenByDescending(record => record.Id, StringComparer.Ordinal)
+            .ToArray();
+
+    public CrashRecord? Get(string id)
+    {
+        foreach (var store in _stores)
+        {
+            try
+            {
+                var record = store.Get(id);
+                if (record is not null)
+                {
+                    return record;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return null;
+    }
+
+    public bool HasReportForRun(string runId)
+        => _stores.Any(store =>
+        {
+            try
+            {
+                return store.HasReportForRun(runId);
+            }
+            catch
+            {
+                return false;
+            }
+        });
+
+    public bool TryAcknowledge(string id)
+        => TryForReport(id, store => store.TryAcknowledge(id));
+
+    public bool TryDelete(string id)
+        => TryForReport(id, store => store.TryDelete(id));
+
+    public int DeleteAll()
+    {
+        var ids = GetAll().Select(record => record.Id).ToArray();
+        var deleted = 0;
+        foreach (var id in ids)
+        {
+            if (TryDelete(id))
+            {
+                deleted++;
+            }
+        }
+
+        return deleted;
+    }
+
+    private bool TryWrite(Func<ICrashReportStore, bool> write)
+    {
+        foreach (var store in _stores)
+        {
+            try
+            {
+                if (write(store))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryForReport(string id, Func<ICrashReportStore, bool> operation)
+    {
+        foreach (var store in _stores)
+        {
+            try
+            {
+                if (store.Get(id) is not null && operation(store))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<CrashRecord> SafeGetAll(ICrashReportStore store)
+    {
+        try
+        {
+            return store.GetAll();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+}
+
+internal static class AtomicFile
+{
+    public static void WriteText(string path, string content)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var temporaryPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes(content);
+            using (var stream = new FileStream(
+                       temporaryPath,
+                       FileMode.CreateNew,
+                       FileAccess.Write,
+                       FileShare.Read,
+                       bufferSize: 4096,
+                       options: FileOptions.WriteThrough))
+            {
+                stream.Write(bytes, 0, bytes.Length);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Move(temporaryPath, path, overwrite: true);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/Emerald.CoreX/CrashHandling/CrashText.cs
+++ b/Emerald.CoreX/CrashHandling/CrashText.cs
@@ -1,0 +1,254 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Emerald.CoreX.CrashHandling;
+
+public static class CrashTextSanitizer
+{
+    private const int DefaultMaxLength = 64 * 1024;
+
+    private static readonly Regex SecretRegex = new(
+        """(?ix)(?<key>["']?(?:authorization|access[_-]?token|refresh[_-]?token|id[_-]?token|token|client[_-]?secret|api[_-]?(?:key|secret)|private[_-]?key|password|passwd|secret|cookie|credential|username|email)["']?)(?<separator>\s*[:=]\s*(?:(?:bearer|basic)\s+)?|\s+(?:bearer|basic)\s+|\s+)(?<value>"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,;&}]+)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex UnixUserPathRegex = new(
+        @"(?i)(?:/Users/|/home/)[^/\s]+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex WindowsUserPathRegex = new(
+        @"(?i)[A-Z]:\\Users\\[^\s\\]+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string Sanitize(string? value, int maxLength = DefaultMaxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = value.Replace("\0", string.Empty, StringComparison.Ordinal);
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            sanitized = sanitized.Replace(home, "<home>", StringComparison.OrdinalIgnoreCase);
+        }
+
+        sanitized = UnixUserPathRegex.Replace(sanitized, "/<home>");
+        sanitized = WindowsUserPathRegex.Replace(sanitized, "<home>");
+        sanitized = SecretRegex.Replace(sanitized, match =>
+            match.Groups["key"].Value + ": [REDACTED]");
+
+        if (sanitized.Length <= maxLength)
+        {
+            return sanitized;
+        }
+
+        return sanitized[..Math.Max(0, maxLength - 32)] + "\n[TRUNCATED]";
+    }
+}
+
+public static class CrashLogTailReader
+{
+    public static string Read(string? path, int maxBytes = 64 * 1024)
+    {
+        if (string.IsNullOrWhiteSpace(path) || maxBytes <= 0)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var readablePath = ResolvePath(path);
+            if (readablePath is null)
+            {
+                return string.Empty;
+            }
+
+            using var stream = File.Open(readablePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var start = Math.Max(0, stream.Length - maxBytes);
+            stream.Seek(start, SeekOrigin.Begin);
+            var bufferLength = (int)Math.Min(maxBytes, Math.Max(0, stream.Length - start));
+            var buffer = new byte[bufferLength];
+            var read = stream.Read(buffer, 0, buffer.Length);
+            return CrashTextSanitizer.Sanitize(Encoding.UTF8.GetString(buffer, 0, read));
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string? ResolvePath(string path)
+    {
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var directory = Path.GetDirectoryName(path);
+        var fileName = Path.GetFileName(path);
+        if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        var extension = Path.GetExtension(fileName);
+        var prefix = Path.GetFileNameWithoutExtension(fileName);
+        try
+        {
+            return new DirectoryInfo(directory)
+                .EnumerateFiles($"{prefix}*{extension}", SearchOption.TopDirectoryOnly)
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .FirstOrDefault()?.FullName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+public static class CrashReportFormatter
+{
+    public static string ToText(CrashRecord record)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("=== EMERALD CRASH REPORT ===");
+        builder.AppendLine($"Report ID: {record.Id}");
+        builder.AppendLine($"Run ID: {record.RunId}");
+        builder.AppendLine($"Type: {record.Kind}");
+        builder.AppendLine($"Occurred (UTC): {record.OccurredUtc:O}");
+        builder.AppendLine($"Source: {CrashTextSanitizer.Sanitize(record.Source, 512)}");
+        builder.AppendLine();
+        builder.AppendLine("=== ENVIRONMENT ===");
+        builder.AppendLine($"App version: {CrashTextSanitizer.Sanitize(record.AppVersion, 512)}");
+        builder.AppendLine($"Package version: {CrashTextSanitizer.Sanitize(record.PackageVersion, 512)}");
+        builder.AppendLine($"Build channel: {CrashTextSanitizer.Sanitize(record.BuildChannel, 512)}");
+        builder.AppendLine($"Release tag: {CrashTextSanitizer.Sanitize(record.ReleaseTag, 512)}");
+        builder.AppendLine($"Commit: {CrashTextSanitizer.Sanitize(record.CommitSha, 512)}");
+        builder.AppendLine($"Build timestamp: {CrashTextSanitizer.Sanitize(record.BuildTimestampUtc, 512)}");
+        builder.AppendLine($"Platform: {CrashTextSanitizer.Sanitize(record.Platform, 512)}");
+        builder.AppendLine($"Operating system: {CrashTextSanitizer.Sanitize(record.OperatingSystem, 1024)}");
+        builder.AppendLine($"Architecture: {CrashTextSanitizer.Sanitize(record.Architecture, 256)}");
+        builder.AppendLine($"Runtime: {CrashTextSanitizer.Sanitize(record.Runtime, 512)}");
+        builder.AppendLine($"Native diagnostics: {CrashTextSanitizer.Sanitize(record.NativeDiagnosticsStatus, 512)}");
+        if (!string.IsNullOrWhiteSpace(record.ReportPath))
+        {
+            builder.AppendLine($"Local report: {CrashTextSanitizer.Sanitize(record.ReportPath, 2048)}");
+        }
+        if (!string.IsNullOrWhiteSpace(record.NativeDiagnosticsPath))
+        {
+            builder.AppendLine($"Native diagnostics path: {CrashTextSanitizer.Sanitize(record.NativeDiagnosticsPath, 2048)}");
+        }
+
+        if (record.Exception is not null)
+        {
+            builder.AppendLine();
+            builder.AppendLine("=== EXCEPTION ===");
+            AppendException(builder, record.Exception, 0);
+        }
+
+        if (!string.IsNullOrWhiteSpace(record.ApplicationLogTail))
+        {
+            builder.AppendLine();
+            builder.AppendLine("=== APPLICATION LOG TAIL ===");
+            builder.AppendLine(CrashTextSanitizer.Sanitize(record.ApplicationLogTail));
+        }
+
+        return builder.ToString();
+    }
+
+    public static string ToGitHubSummary(CrashRecord record)
+    {
+        var exception = record.Exception;
+        var builder = new StringBuilder();
+        builder.AppendLine("## Emerald crash report");
+        builder.AppendLine();
+        builder.AppendLine("The full sanitized report has been copied to the clipboard by Emerald.");
+        builder.AppendLine();
+        builder.AppendLine("| Field | Value |");
+        builder.AppendLine("| --- | --- |");
+        builder.AppendLine($"| Report ID | {record.Id} |");
+        builder.AppendLine($"| Type | {record.Kind} |");
+        builder.AppendLine($"| Version | {EscapeTable(record.AppVersion)} |");
+        builder.AppendLine($"| Platform | {EscapeTable(record.Platform)} |");
+        builder.AppendLine($"| Source | {EscapeTable(record.Source)} |");
+        builder.AppendLine($"| Exception | {EscapeTable(exception?.Type ?? "Unavailable")} |");
+        builder.AppendLine();
+        builder.AppendLine("Please paste the copied report below and describe what Emerald was doing before the crash.");
+        return builder.ToString();
+    }
+
+    public static string ToGitHubTitle(CrashRecord record)
+        => $"Emerald {record.Kind.ToString().ToLowerInvariant()} - "
+           + $"{CrashTextSanitizer.Sanitize(record.AppVersion, 128)} - "
+           + CrashTextSanitizer.Sanitize(record.Platform, 128);
+
+    private static void AppendException(StringBuilder builder, CrashExceptionInfo exception, int depth)
+    {
+        var indent = new string(' ', depth * 2);
+        builder.AppendLine($"{indent}Type: {CrashTextSanitizer.Sanitize(exception.Type, 1024)}");
+        builder.AppendLine($"{indent}Message: {CrashTextSanitizer.Sanitize(exception.Message, 16_384)}");
+        builder.AppendLine($"{indent}HResult: {exception.HResult?.ToString() ?? "Unavailable"}");
+        builder.AppendLine($"{indent}Stack trace:");
+        builder.AppendLine(CrashTextSanitizer.Sanitize(exception.StackTrace, 32_768));
+
+        foreach (var inner in exception.InnerExceptions)
+        {
+            builder.AppendLine($"{indent}Inner exception:");
+            AppendException(builder, inner, depth + 1);
+        }
+    }
+
+    private static string EscapeTable(string value)
+        => CrashTextSanitizer.Sanitize(value, 256)
+            .Replace("|", "\\|", StringComparison.Ordinal)
+            .Replace(((char)96).ToString(), "'", StringComparison.Ordinal);
+}
+
+public sealed record GitHubIssueDraft(string Url, string Title, string Body, string FullReport);
+
+public sealed class GitHubCrashIssueComposer
+{
+    private const int MaximumEncodedUrlLength = 2_000;
+    private readonly string _repositoryUrl;
+
+    public GitHubCrashIssueComposer(string repositoryUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryUrl);
+        _repositoryUrl = repositoryUrl.TrimEnd('/');
+    }
+
+    public GitHubIssueDraft Compose(CrashRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var title = CrashReportFormatter.ToGitHubTitle(record);
+        var body = CrashReportFormatter.ToGitHubSummary(record);
+        var url = ComposeUrl(title, body);
+        return new GitHubIssueDraft(url, title, body, CrashReportFormatter.ToText(record));
+    }
+
+    private string ComposeUrl(string title, string body)
+    {
+        var url = BuildUrl(title, body);
+        if (url.Length <= MaximumEncodedUrlLength)
+        {
+            return url;
+        }
+
+        var compactBody = "## Emerald crash report\n\n"
+            + "Report ID: " + CrashTextSanitizer.Sanitize(title, 128) + "\n"
+            + "Please paste the complete sanitized report from the clipboard.";
+        url = BuildUrl(CrashTextSanitizer.Sanitize(title, 96), compactBody);
+        if (url.Length <= MaximumEncodedUrlLength)
+        {
+            return url;
+        }
+
+        return BuildUrl("Emerald crash report", "Please paste the complete sanitized report from the clipboard.");
+    }
+
+    private string BuildUrl(string title, string body)
+        => $"{_repositoryUrl}/issues/new?template=crash_report.md&title={Uri.EscapeDataString(title)}&body={Uri.EscapeDataString(body)}";
+}

--- a/Emerald.CoreX/CrashHandling/PlatformDiagnostics.cs
+++ b/Emerald.CoreX/CrashHandling/PlatformDiagnostics.cs
@@ -1,0 +1,13 @@
+namespace Emerald.CoreX.CrashHandling;
+
+public interface IPlatformDiagnosticsProvider
+{
+    PlatformDiagnosticsResult FindRecent(DateTimeOffset occurredUtc);
+}
+public sealed record PlatformDiagnosticsResult(string Status, string? Path = null)
+{
+    public bool IsAvailable => !string.IsNullOrWhiteSpace(Path);
+
+    public static PlatformDiagnosticsResult Unavailable(string reason)
+        => new(reason);
+}

--- a/Emerald.CoreX/Helpers/Extensions.cs
+++ b/Emerald.CoreX/Helpers/Extensions.cs
@@ -130,14 +130,26 @@ public static class Extensions
 
     public static string Localize(this string resourceKey)
     {
-        var _logger = Ioc.Default.GetService<ILogger<ResourceLoader>>();
+        // Recovery UI can run before the application host and CommunityToolkit
+        // service provider have been initialized. Logging is useful here, but
+        // it must never make localization itself fail.
+        ILogger<ResourceLoader>? logger = null;
         try
         {
-            _logger.LogDebug("Localizing {resourceKey}", resourceKey);
+            logger = Ioc.Default.GetService<ILogger<ResourceLoader>>();
+        }
+        catch
+        {
+            // No host yet: continue with resource lookup and the key fallback.
+        }
+
+        try
+        {
+            logger?.LogDebug("Localizing {resourceKey}", resourceKey);
 
             if (cachedResources.TryGetValue(resourceKey, out string cached) && !string.IsNullOrEmpty(cached))
             {
-                _logger.LogDebug("Found cached {resourceKey} in cache", resourceKey);
+                logger?.LogDebug("Found cached {resourceKey} in cache", resourceKey);
                 return cached;
             }
 
@@ -147,18 +159,18 @@ public static class Extensions
 
             if (string.IsNullOrEmpty(s))
             {
-                _logger.LogWarning("ResourceLoader.GetString returned empty/null, returning defaultkey");
+                logger?.LogWarning("ResourceLoader.GetString returned empty/null, returning defaultkey");
                 return resourceKey;
             }
                 
             cachedResources.AddOrUpdate(resourceKey, s, (_, _) => s);
             
-            _logger.LogDebug("Localized {resourceKey} to {s}", resourceKey, s);
+            logger?.LogDebug("Localized {resourceKey} to {s}", resourceKey, s);
             return string.IsNullOrEmpty(s) ? resourceKey : s;
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to localize {resourceKey}", resourceKey);
+            logger?.LogWarning(ex, "Failed to localize {resourceKey}", resourceKey);
             return resourceKey;
         }
     }

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -356,82 +356,113 @@ Notes
         try
         {
             await WaitForRootAsync(rootFrame);
-
-            var pendingReport = _crashCoordinator.GetUnacknowledgedReports().FirstOrDefault();
-            var showRecovery = !CrashFaultInjection.IsArmed
-                && (pendingReport is not null || _crashCoordinator.IsRecoveryMode);
-            if (showRecovery)
-            {
-                await ShowPendingCrashAtStartupAsync(rootFrame,
-                    pendingReport ?? _crashCoordinator.GetReports().FirstOrDefault());
-                if (!_normalStartupChosen)
-                {
-                    return;
-                }
-            }
-
+            var showRecovery = await ShowRecoveryIfNeededAsync(rootFrame);
+            if (showRecovery && !_normalStartupChosen) return;
             _crashCoordinator.MarkNormalStartupAttempted();
-            Host = builder.Build();
-            Ioc.Default.ConfigureServices(Host.Services);
-            NativeDispatcherFatalLoggerProvider.AttachHost(Host.Services.GetRequiredService<ILoggerFactory>());
-            _crashCoordinator.SetLogger(Host.Services.GetRequiredService<ILogger<CrashCoordinator>>());
-            this.Log().LogInformation("Application host built successfully. LogPath: {LogPath}.", _crashCoordinator.ApplicationLogPath);
-
-            SS = Ioc.Default.GetRequiredService<Services.SettingsService>();
-            SS.LoadData();
-            this.Log().LogInformation("Application settings loaded.");
-
-            var core = Ioc.Default.GetRequiredService<CoreX.Core>();
-            var configuredMinecraftPath = SS.Settings.Minecraft.Path;
-            var startupMinecraftPath = string.IsNullOrWhiteSpace(configuredMinecraftPath)
-                ? new MinecraftPath()
-                : new MinecraftPath(configuredMinecraftPath);
-            core.InitializeLocalAsync(startupMinecraftPath).GetAwaiter().GetResult();
-            if (!_crashCoordinator.IsRecoveryMode)
-            {
-                _ = RunBackgroundStartupTaskAsync(
-                    () => core.RefreshVersionCatalogAsync(),
-                    "Minecraft version catalog refresh");
-            }
-
-            var ac = Ioc.Default.GetRequiredService<CoreX.Services.IAccountService>();
-            _ = RunBackgroundStartupTaskAsync(() => ac.InitializeAsync(), "Account service initialization");
-
-            if (rootFrame.Content is not null && rootFrame.Content is not MainPage)
-            {
-                rootFrame.Content = null;
-            }
-
-            if (rootFrame.Content is null)
-            {
-                rootFrame.Navigate(typeof(MainPage), args.Arguments);
-                this.Log().LogInformation("Navigated to the main page.");
-            }
-
-            MainWindow!.Activate();
-            if (rootFrame.Content is MainPage mainPage)
-            {
-                await mainPage.ShellReady;
-            }
-
-            _crashCoordinator.MarkStartupComplete();
-            CrashFaultInjection.WriteCheckpoint("ShellReady");
-            this.Log().LogInformation("Main shell is ready.");
-            _ = Task.Run(_crashCoordinator.EnrichNativeDiagnostics);
-
-            if (!_crashCoordinator.IsRecoveryMode)
-            {
-                if (!showRecovery)
-                {
-                    await ShowReleaseNotesAtStartupAsync();
-                }
-                await CheckForUpdatesAtStartupAsync();
-            }
+            BuildHost(builder);
+            await InitializeApplicationAsync(args, rootFrame, showRecovery);
         }
         catch (Exception exception)
         {
             _crashCoordinator.CaptureAndTerminate(exception, "Startup");
         }
+    }
+
+    private async Task<bool> ShowRecoveryIfNeededAsync(Frame rootFrame)
+    {
+        var pendingReport = _crashCoordinator.GetUnacknowledgedReports().FirstOrDefault();
+        var shouldShow = !CrashFaultInjection.IsArmed
+            && (pendingReport is not null || _crashCoordinator.IsRecoveryMode);
+        if (!shouldShow) return false;
+
+        await ShowPendingCrashAtStartupAsync(rootFrame,
+            pendingReport ?? _crashCoordinator.GetReports().FirstOrDefault());
+        return true;
+    }
+
+    private void BuildHost(IApplicationBuilder builder)
+    {
+        Host = builder.Build();
+        Ioc.Default.ConfigureServices(Host.Services);
+        NativeDispatcherFatalLoggerProvider.AttachHost(Host.Services.GetRequiredService<ILoggerFactory>());
+        _crashCoordinator.SetLogger(Host.Services.GetRequiredService<ILogger<CrashCoordinator>>());
+        this.Log().LogInformation("Application host built successfully. LogPath: {LogPath}.", _crashCoordinator.ApplicationLogPath);
+    }
+
+    private async Task InitializeApplicationAsync(
+        LaunchActivatedEventArgs args,
+        Frame rootFrame,
+        bool showedRecovery)
+    {
+        LoadSettings();
+        await InitializeCoreAsync();
+        await InitializeMainShellAsync(args, rootFrame);
+        MarkShellReady();
+        await ShowOptionalStartupDialogsAsync(showedRecovery);
+    }
+
+    private void LoadSettings()
+    {
+        SS = Ioc.Default.GetRequiredService<Services.SettingsService>();
+        SS.LoadData();
+        this.Log().LogInformation("Application settings loaded.");
+    }
+
+    private async Task InitializeCoreAsync()
+    {
+        var core = Ioc.Default.GetRequiredService<CoreX.Core>();
+        var configuredMinecraftPath = SS.Settings.Minecraft.Path;
+        var startupMinecraftPath = string.IsNullOrWhiteSpace(configuredMinecraftPath)
+            ? new MinecraftPath()
+            : new MinecraftPath(configuredMinecraftPath);
+
+        await core.InitializeLocalAsync(startupMinecraftPath);
+        if (!_crashCoordinator.IsRecoveryMode)
+        {
+            _ = RunBackgroundStartupTaskAsync(
+                () => core.RefreshVersionCatalogAsync(),
+                "Minecraft version catalog refresh");
+        }
+
+        var accountService = Ioc.Default.GetRequiredService<CoreX.Services.IAccountService>();
+        _ = RunBackgroundStartupTaskAsync(
+            () => accountService.InitializeAsync(),
+            "Account service initialization");
+    }
+
+    private async Task InitializeMainShellAsync(LaunchActivatedEventArgs args, Frame rootFrame)
+    {
+        if (rootFrame.Content is not null && rootFrame.Content is not MainPage)
+        {
+            rootFrame.Content = null;
+        }
+
+        if (rootFrame.Content is null)
+        {
+            rootFrame.Navigate(typeof(MainPage), args.Arguments);
+            this.Log().LogInformation("Navigated to the main page.");
+        }
+
+        MainWindow!.Activate();
+        if (rootFrame.Content is MainPage mainPage)
+        {
+            await mainPage.ShellReady;
+        }
+    }
+
+    private void MarkShellReady()
+    {
+        _crashCoordinator.MarkStartupComplete();
+        CrashFaultInjection.WriteCheckpoint("ShellReady");
+        this.Log().LogInformation("Main shell is ready.");
+        _ = Task.Run(_crashCoordinator.EnrichNativeDiagnostics);
+    }
+
+    private async Task ShowOptionalStartupDialogsAsync(bool showedRecovery)
+    {
+        if (_crashCoordinator.IsRecoveryMode) return;
+        if (!showedRecovery) await ShowReleaseNotesAtStartupAsync();
+        await CheckForUpdatesAtStartupAsync();
     }
 
     private bool _normalStartupChosen;
@@ -611,119 +642,148 @@ Notes
     {
         try
         {
-            var openLogsButton = new Button
-            {
-                Content = "OpenCrashLogs".Localize(),
-                HorizontalAlignment = HorizontalAlignment.Left
-            };
-
-            var content = new StackPanel { Spacing = 12 };
-            content.Children.Add(new TextBlock
-            {
-                Text = _crashCoordinator.IsRecoveryMode
-                    ? "RecoveryModeDescription".Localize()
-                    : record?.Kind == CrashRecordKind.UnexpectedShutdown
-                    ? "UnexpectedShutdownDescription".Localize()
-                    : "CrashRecoveryDescription".Localize(),
-                TextWrapping = TextWrapping.WrapWholeWords
-            });
-            content.Children.Add(new TextBlock
-            {
-                Text = record is null ? string.Empty
-                    : $"{record.AppVersion} · {record.Platform} · {record.OccurredUtc.ToLocalTime():g}",
-                TextWrapping = TextWrapping.WrapWholeWords
-            });
-            content.Children.Add(openLogsButton);
-            var details = CreateRecoveryDetails(record);
-            details.Visibility = Visibility.Collapsed;
-            content.Children.Add(details);
-            var status = new TextBlock { TextWrapping = TextWrapping.WrapWholeWords };
-            content.Children.Add(status);
-
-            var dialog = new ContentDialog
-            {
-                Title = (_crashCoordinator.IsRecoveryMode ? "RecoveryMode" : "EmeraldCrashDetected").Localize(),
-                Content = content,
-                PrimaryButtonText = "ViewCrashReport".Localize(),
-                SecondaryButtonText = "ReportToGitHub".Localize(),
-                CloseButtonText = (_crashCoordinator.IsRecoveryMode ? "TryNormalStartup" : "Continue").Localize(),
-                IsPrimaryButtonEnabled = record is not null,
-                IsSecondaryButtonEnabled = record is not null,
-                DefaultButton = ContentDialogButton.Primary,
-                XamlRoot = root.XamlRoot
-            };
-
-            void Acknowledge()
-            {
-                if (record is not null) _crashCoordinator.Acknowledge(record.Id);
-            }
-            void ViewDetails()
-            {
-                Acknowledge();
-                var show = details.Visibility != Visibility.Visible;
-                details.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
-                dialog.PrimaryButtonText = (show ? "HideCrashDetails" : "ViewCrashReport").Localize();
-                CrashFaultInjection.WriteCheckpoint("Recovery details viewed");
-            }
-            void ContinueStartup()
-            {
-                Acknowledge();
-                _normalStartupChosen = true;
-            }
-            dialog.PrimaryButtonClick += (_, args) =>
-            {
-                args.Cancel = true;
-                ViewDetails();
-            };
-            dialog.SecondaryButtonClick += async (_, args) =>
-            {
-                args.Cancel = true;
-                Acknowledge();
-                dialog.IsSecondaryButtonEnabled = false;
-                try
-                {
-                    if (record is not null) await ReportCrashOnGitHubAsync(record);
-                }
-                catch (Exception exception)
-                {
-                    status.Text = "CouldNotOpenGitHubReport".Localize();
-                    this.Log().LogWarning(exception, "Could not open GitHub from recovery.");
-                }
-                finally { dialog.IsSecondaryButtonEnabled = record is not null; }
-            };
-            dialog.CloseButtonClick += (_, _) => ContinueStartup();
-            openLogsButton.Click += async (_, _) =>
-            {
-                Acknowledge();
-                try { await OpenCrashLogsAsync(); }
-                catch (Exception exception)
-                {
-                    this.Log().LogWarning(exception, "Could not open logs from recovery.");
-                }
-            };
-            dialog.Opened += (_, _) =>
-            {
-                CrashFaultInjection.WriteCheckpoint($"Recovery dialog opened: {record?.Id ?? "none"}");
-                CrashFaultInjection.ExerciseRecoveryActions(root.DispatcherQueue, ViewDetails, () =>
-                {
-                    ContinueStartup();
-                    dialog.Hide();
-                });
-            };
-
-            await dialog.ShowAsync();
-            // Escape or programmatic cancellation is not a user acknowledgement.
-            // Keep recovery accessible inline instead of presenting another modal.
-            if (!_normalStartupChosen)
-            {
-                await ShowEmergencyRecoveryPanelAsync(root, record);
-            }
+            var context = CreateRecoveryDialog(root, record);
+            WireRecoveryDialog(context, root);
+            await context.Dialog.ShowAsync();
+            await ShowEmergencyPanelIfNeededAsync(root, record);
         }
         catch (Exception exception)
         {
             this.Log().LogWarning(exception, "Previous-crash recovery dialog failed to open.");
             await ShowEmergencyRecoveryPanelAsync(root, record);
         }
+    }
+
+    private RecoveryDialogContext CreateRecoveryDialog(FrameworkElement root, CrashRecord? record)
+    {
+        var openLogsButton = new Button
+        {
+            Content = "OpenCrashLogs".Localize(),
+            HorizontalAlignment = HorizontalAlignment.Left
+        };
+        var details = CreateRecoveryDetails(record);
+        details.Visibility = Visibility.Collapsed;
+        var status = new TextBlock { TextWrapping = TextWrapping.WrapWholeWords };
+        var content = new StackPanel { Spacing = 12 };
+        content.Children.Add(new TextBlock
+        {
+            Text = GetRecoveryDescription(record),
+            TextWrapping = TextWrapping.WrapWholeWords
+        });
+        content.Children.Add(new TextBlock
+        {
+            Text = record is null ? string.Empty
+                : $"{record.AppVersion} · {record.Platform} · {record.OccurredUtc.ToLocalTime():g}",
+            TextWrapping = TextWrapping.WrapWholeWords
+        });
+        content.Children.Add(openLogsButton);
+        content.Children.Add(details);
+        content.Children.Add(status);
+
+        var dialog = new ContentDialog
+        {
+            Title = (_crashCoordinator.IsRecoveryMode ? "RecoveryMode" : "EmeraldCrashDetected").Localize(),
+            Content = content,
+            PrimaryButtonText = "ViewCrashReport".Localize(),
+            SecondaryButtonText = "ReportToGitHub".Localize(),
+            CloseButtonText = (_crashCoordinator.IsRecoveryMode ? "TryNormalStartup" : "Continue").Localize(),
+            IsPrimaryButtonEnabled = record is not null,
+            IsSecondaryButtonEnabled = record is not null,
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = root.XamlRoot
+        };
+        return new RecoveryDialogContext(dialog, openLogsButton, details, status, record);
+    }
+
+    private string GetRecoveryDescription(CrashRecord? record)
+    {
+        if (_crashCoordinator.IsRecoveryMode) return "RecoveryModeDescription".Localize();
+        if (record?.Kind == CrashRecordKind.UnexpectedShutdown) return "UnexpectedShutdownDescription".Localize();
+        return "CrashRecoveryDescription".Localize();
+    }
+
+    private void WireRecoveryDialog(RecoveryDialogContext context, FrameworkElement root)
+    {
+        context.Dialog.PrimaryButtonClick += (_, args) =>
+        {
+            args.Cancel = true;
+            ViewRecoveryDetails(context);
+        };
+        context.Dialog.SecondaryButtonClick += async (_, args) =>
+            await ReportFromRecoveryDialogAsync(context, args);
+        context.Dialog.CloseButtonClick += (_, _) => ContinueFromRecovery(context);
+        context.OpenLogsButton.Click += async (_, _) =>
+            await OpenLogsFromRecoveryAsync(context.Record);
+        context.Dialog.Opened += (_, _) =>
+        {
+            CrashFaultInjection.WriteCheckpoint($"Recovery dialog opened: {context.Record?.Id ?? "none"}");
+            CrashFaultInjection.ExerciseRecoveryActions(root.DispatcherQueue,
+                () => ViewRecoveryDetails(context),
+                () =>
+                {
+                    ContinueFromRecovery(context);
+                    context.Dialog.Hide();
+                });
+        };
+    }
+
+    private void ViewRecoveryDetails(RecoveryDialogContext context)
+    {
+        Acknowledge(context.Record);
+        var show = context.Details.Visibility != Visibility.Visible;
+        context.Details.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+        context.Dialog.PrimaryButtonText = (show ? "HideCrashDetails" : "ViewCrashReport").Localize();
+        CrashFaultInjection.WriteCheckpoint("Recovery details viewed");
+    }
+
+    private void ContinueFromRecovery(RecoveryDialogContext context)
+    {
+        Acknowledge(context.Record);
+        _normalStartupChosen = true;
+    }
+
+    private void Acknowledge(CrashRecord? record)
+    {
+        if (record is not null) _crashCoordinator.Acknowledge(record.Id);
+    }
+
+    private async Task ReportFromRecoveryDialogAsync(
+        RecoveryDialogContext context,
+        ContentDialogButtonClickEventArgs args)
+    {
+        args.Cancel = true;
+        Acknowledge(context.Record);
+        context.Dialog.IsSecondaryButtonEnabled = false;
+        try
+        {
+            if (context.Record is not null) await ReportCrashOnGitHubAsync(context.Record);
+        }
+        catch (Exception exception)
+        {
+            context.Status.Text = "CouldNotOpenGitHubReport".Localize();
+            this.Log().LogWarning(exception, "Could not open GitHub from recovery.");
+        }
+        finally
+        {
+            context.Dialog.IsSecondaryButtonEnabled = context.Record is not null;
+        }
+    }
+
+    private async Task OpenLogsFromRecoveryAsync(CrashRecord? record)
+    {
+        Acknowledge(record);
+        try { await OpenCrashLogsAsync(); }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not open logs from recovery.");
+        }
+    }
+
+    private async Task ShowEmergencyPanelIfNeededAsync(FrameworkElement root, CrashRecord? record)
+    {
+        // Escape or programmatic cancellation is not a user acknowledgement.
+        // Keep recovery accessible inline instead of presenting another modal.
+        if (!_normalStartupChosen) await ShowEmergencyRecoveryPanelAsync(root, record);
     }
 
     private static FrameworkElement CreateRecoveryDetails(CrashRecord? record)
@@ -741,6 +801,18 @@ Notes
     private async Task ShowEmergencyRecoveryPanelAsync(FrameworkElement root, CrashRecord? record)
     {
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var panel = CreateEmergencyRecoveryPanel(record, completion);
+        if (root is Frame frame)
+        {
+            frame.Content = panel;
+        }
+        await completion.Task;
+    }
+
+    private StackPanel CreateEmergencyRecoveryPanel(
+        CrashRecord? record,
+        TaskCompletionSource completion)
+    {
         var panel = new StackPanel { Spacing = 12, Padding = new(24) };
         panel.Children.Add(new TextBlock
         {
@@ -748,69 +820,79 @@ Notes
             TextWrapping = TextWrapping.WrapWholeWords
         });
 
-        var viewButton = new Button { Content = "ViewCrashReports".Localize() };
         var details = CreateRecoveryDetails(record);
         details.Visibility = Visibility.Collapsed;
+        var viewButton = new Button { Content = "ViewCrashReports".Localize() };
         viewButton.Click += (_, _) =>
         {
-            if (record is not null)
-            {
-                _crashCoordinator.Acknowledge(record.Id);
-            }
+            Acknowledge(record);
             details.Visibility = Visibility.Visible;
         };
         panel.Children.Add(viewButton);
         panel.Children.Add(details);
 
-        if (record is not null)
+        AddEmergencyReportActions(panel, record);
+        AddEmergencyContinueAction(panel, record, completion);
+        return panel;
+    }
+
+    private void AddEmergencyReportActions(StackPanel panel, CrashRecord? record)
+    {
+        if (record is null) return;
+
+        var reportButton = new Button { Content = "ReportToGitHub".Localize() };
+        reportButton.Click += async (_, _) =>
+            await ReportFromEmergencyPanelAsync(record);
+        panel.Children.Add(reportButton);
+
+        var openLogsButton = new Button { Content = "OpenCrashLogs".Localize() };
+        openLogsButton.Click += async (_, _) =>
+            await OpenLogsFromEmergencyPanelAsync(record);
+        panel.Children.Add(openLogsButton);
+    }
+
+    private async Task ReportFromEmergencyPanelAsync(CrashRecord record)
+    {
+        try
         {
-            var reportButton = new Button { Content = "ReportToGitHub".Localize() };
-            reportButton.Click += async (_, _) =>
-            {
-                try
-                {
-                    _crashCoordinator.Acknowledge(record.Id);
-                    await ReportCrashOnGitHubAsync(record);
-                }
-                catch (Exception exception)
-                {
-                    this.Log().LogWarning(exception, "Could not report the previous crash from the recovery panel.");
-                }
-            };
-            panel.Children.Add(reportButton);
-
-            var openLogsButton = new Button { Content = "OpenCrashLogs".Localize() };
-            openLogsButton.Click += async (_, _) =>
-            {
-                try
-                {
-                    _crashCoordinator.Acknowledge(record.Id);
-                    await OpenCrashLogsAsync();
-                }
-                catch (Exception exception)
-                {
-                    this.Log().LogWarning(exception, "Could not open logs from the recovery panel.");
-                }
-            };
-            panel.Children.Add(openLogsButton);
+            Acknowledge(record);
+            await ReportCrashOnGitHubAsync(record);
         }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not report the previous crash from the recovery panel.");
+        }
+    }
 
+    private async Task OpenLogsFromEmergencyPanelAsync(CrashRecord record)
+    {
+        try
+        {
+            Acknowledge(record);
+            await OpenCrashLogsAsync();
+        }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not open logs from the recovery panel.");
+        }
+    }
+
+    private void AddEmergencyContinueAction(
+        StackPanel panel,
+        CrashRecord? record,
+        TaskCompletionSource completion)
+    {
         var continueButton = new Button
         {
             Content = (_crashCoordinator.IsRecoveryMode ? "TryNormalStartup" : "Continue").Localize()
         };
         continueButton.Click += (_, _) =>
         {
-            if (record is not null) _crashCoordinator.Acknowledge(record.Id);
+            Acknowledge(record);
             _normalStartupChosen = true;
             completion.TrySetResult();
         };
         panel.Children.Add(continueButton);
-        if (root is Frame frame)
-        {
-            frame.Content = panel;
-        }
-        await completion.Task;
     }
 
     private async Task ReportCrashOnGitHubAsync(CrashRecord record)
@@ -846,6 +928,20 @@ Notes
         }
 
         return Task.CompletedTask;
+    }
+
+    private sealed class RecoveryDialogContext(
+        ContentDialog dialog,
+        Button openLogsButton,
+        FrameworkElement details,
+        TextBlock status,
+        CrashRecord? record)
+    {
+        public ContentDialog Dialog { get; } = dialog;
+        public Button OpenLogsButton { get; } = openLogsButton;
+        public FrameworkElement Details { get; } = details;
+        public TextBlock Status { get; } = status;
+        public CrashRecord? Record { get; } = record;
     }
 
     #endregion

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -347,7 +347,7 @@ Notes
             CompleteNormalShutdown();
             Environment.Exit(0);
         });
-#if !WINDOWS
+#if EMERALD_MACOS
         MacApplicationTerminationObserver.Register(CompleteNormalShutdown);
 #endif
         _startupTask ??= ContinueStartupAsync(builder, args, rootFrame);

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -56,11 +56,14 @@ Notes
     {
         CrashFaultInjection.ConfigureFromArguments(Environment.GetCommandLineArgs().Skip(1));
         _crashCoordinator = CrashBootstrap.Initialize();
-        this.UnhandledException += App_UnhandledException;
 
         try
         {
             this.InitializeComponent();
+            // Uno's generated handler is registered during application setup. Subscribe
+            // afterward so an attached Debugger can break there before Emerald records
+            // and terminates if execution resumes.
+            this.UnhandledException += App_UnhandledException;
         }
         catch (Exception exception)
         {
@@ -636,8 +639,17 @@ Notes
     #region UnhandledExceptions
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+        => HandleUnoUnhandledException(e.Exception);
+
+    /// <summary>
+    /// Applies Emerald's fatal policy after Uno has surfaced an unhandled UI exception.
+    /// The Debug-only fault injector shares this method to validate the policy without
+    /// pretending it can manufacture Uno framework event delivery.
+    /// </summary>
+    internal void HandleUnoUnhandledException(Exception exception)
     {
-        _crashCoordinator.CaptureAndTerminate(e.Exception, "UI.UnhandledException");
+        CrashFaultInjection.WriteCheckpoint("Uno Application.UnhandledException observed");
+        _crashCoordinator.CaptureAndTerminate(exception, "Uno.Application.UnhandledException");
     }
 
     private async Task ShowPendingCrashAtStartupAsync(FrameworkElement root, CrashRecord? record)

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Diagnostics;
 using System.Reflection;
 using CmlLib.Core;
 using CommonServiceLocator;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Emerald.CoreX.CrashHandling;
 using Emerald.CoreX.Helpers;
 using Emerald.CoreX.Notifications;
 using Emerald.CoreX.Services.Auth;
@@ -14,6 +14,7 @@ using Emerald.CoreX.Store.Modrinth;
 using Emerald.Helpers;
 using Emerald.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml.Controls;
 using Serilog;
 using Serilog.Sinks.File;
@@ -21,6 +22,8 @@ using Microsoft.UI.Dispatching;
 using Uno.Extensions;
 using Uno.Extensions.Hosting;
 using Uno.Resizetizer;
+using Windows.ApplicationModel.DataTransfer;
+using Launcher = Windows.System.Launcher;
 
 namespace Emerald;
 
@@ -40,7 +43,10 @@ Notes
 - You can still change the Minecraft path from Settings.
 """;
 
-    private Services.SettingsService SS;
+    private Services.SettingsService SS = null!;
+    private readonly CrashCoordinator _crashCoordinator;
+    private Task? _startupTask;
+    private int _normalShutdownStarted;
 
     /// <summary>
     /// Initializes the singleton application object. This is the first line of authored code
@@ -48,27 +54,23 @@ Notes
     /// </summary>
     public App()
     {
-        this.InitializeComponent();
-
-        // Fires BEFORE any catch block — catches swallowed exceptions
-        AppDomain.CurrentDomain.FirstChanceException += (s, e) =>
-        {
-            // Only log exceptions from your own assemblies to avoid noise
-            var ns = e.Exception.TargetSite?.DeclaringType?.Namespace ?? "";
-            if (ns.StartsWith("Emerald") || ns.StartsWith("CmlLib"))
-            {
-                Debug.WriteLine($"[FIRST CHANCE] {e.Exception.GetType().Name}: {e.Exception.Message}");
-                Debug.WriteLine($"[FIRST CHANCE STACK] {e.Exception.StackTrace}");
-            }
-        };
-
+        CrashFaultInjection.ConfigureFromArguments(Environment.GetCommandLineArgs().Skip(1));
+        _crashCoordinator = CrashBootstrap.Initialize();
         this.UnhandledException += App_UnhandledException;
-        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-        TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+
+        try
+        {
+            this.InitializeComponent();
+        }
+        catch (Exception exception)
+        {
+            _crashCoordinator.CaptureAndTerminate(exception, "App constructor");
+        }
     }
 
     public Window? MainWindow { get; private set; }
     protected IHost? Host { get; private set; }
+    public CrashCoordinator CrashCoordinator => _crashCoordinator;
 
     #region  Services
 
@@ -247,6 +249,7 @@ Notes
         services.AddTransient<ViewModels.NotificationListViewModel>();
         services.AddSingleton<ViewModels.AccountsPageViewModel>();
         services.AddTransient<ViewModels.LogsPageViewModel>();
+        services.AddTransient<ViewModels.CrashReportsPageViewModel>();
         services.AddTransient<ViewModels.ModrinthStorePageViewModel>();
         services.AddTransient<ViewModels.GameOptionsViewModel>();
     }
@@ -258,6 +261,8 @@ Notes
     /// </summary>
     private void ConfigureServices(IServiceCollection services)
     {
+        services.AddSingleton(_crashCoordinator);
+        services.AddSingleton<ICrashReportStore>(_crashCoordinator.Store);
         ConfigureCoreServices(services);
         ConfigureSettingsServices(services);
         ConfigureAuthServices(services);
@@ -270,7 +275,33 @@ Notes
     /// </summary>
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-        var logPath = Path.Combine(DirectResoucres.LocalDataPath, "logs", "app_.log");
+        try
+        {
+            CrashFaultInjection.ConfigureFromActivationArguments(args.Arguments);
+#if DEBUG
+            if (CrashFaultInjection.IsRequested("WinAppStartup"))
+            {
+                throw new NotImplementedException("Intentional WinAppSDK startup crash test.");
+            }
+#endif
+            OnLaunchedCore(args);
+        }
+        catch (Exception exception)
+        {
+            _crashCoordinator.CaptureAndTerminate(exception, "OnLaunched");
+        }
+    }
+
+    private void OnLaunchedCore(LaunchActivatedEventArgs args)
+    {
+        var logPath = _crashCoordinator.ApplicationLogPath;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+        }
+        catch
+        {
+        }
 
         var builder = this.CreateBuilder(args)
             .Configure(host => host
@@ -279,6 +310,8 @@ Notes
 #endif
                 .UseSerilog(true, configureLogger: x => x
                     .MinimumLevel.Debug()
+                    .MinimumLevel.Override("Microsoft.UI", Serilog.Events.LogEventLevel.Warning)
+                    .MinimumLevel.Override("Uno", Serilog.Events.LogEventLevel.Warning)
                     .WriteTo.File(logPath,
                         rollingInterval: RollingInterval.Day,
                         retainedFileCountLimit: 7,
@@ -288,43 +321,15 @@ Notes
 
         MainWindow = builder.Window;
 #if DEBUG
-        MainWindow.UseStudio();
+        if (!CrashFaultInjection.DisableStudio)
+        {
+            MainWindow.UseStudio();
+        }
 #endif
         MainWindow.SetWindowIcon("Assets/Icon.ico");
 
-        Host = builder.Build();
-        Ioc.Default.ConfigureServices(Host.Services);
-        this.Log().LogInformation("Application host built successfully. LogPath: {LogPath}.", logPath);
-
-        SS = Ioc.Default.GetService<Services.SettingsService>();
-
-        //load settings,
-        SS.LoadData();
-        this.Log().LogInformation("Application settings loaded.");
-
-        var core = Ioc.Default.GetRequiredService<CoreX.Core>();
-        var configuredMinecraftPath = SS.Settings.Minecraft.Path;
-        var startupMinecraftPath = string.IsNullOrWhiteSpace(configuredMinecraftPath)
-            ? new MinecraftPath()
-            : new MinecraftPath(configuredMinecraftPath);
-        try
-        {
-            // Local game state is available before navigation; the catalog refresh is
-            // deliberately silent and bounded so offline startup never blocks Home.
-            core.InitializeLocalAsync(startupMinecraftPath).GetAwaiter().GetResult();
-            _ = core.RefreshVersionCatalogAsync();
-        }
-        catch (Exception ex)
-        {
-            this.Log().LogWarning(ex, "Could not initialize local Minecraft state at startup.");
-        }
-
-        var ac = Ioc.Default.GetService<CoreX.Services.IAccountService>();
-        _ = ac.InitializeAsync();
-        this.Log().LogInformation("Account service initialization requested.");
-
-        // Do not repeat app initialization when the Window already has content,
-        // just ensure that the window is active
+        // The window and blank root exist before the host and MainPage. This is the
+        // only safe place to present recovery after an early startup failure.
         if (MainWindow.Content is not Frame rootFrame)
         {
             // Create a Frame to act as the navigation context and navigate to the first page
@@ -335,20 +340,127 @@ Notes
             this.Log().LogDebug("Created a new root navigation frame for the main window.");
         }
 
-        // When the navigation stack isn't restored navigate to the first page,
-        // configuring the new page by passing required information as a navigation
-        // parameter
-        if (rootFrame.Content == null)
-        {
-            rootFrame.Navigate(typeof(MainPage), args.Arguments);
-            this.Log().LogInformation("Navigated to the main page.");
-        }
-
         MainWindow.Activate();
         MainWindow.Closed += MainWindow_Closed;
-        this.Log().LogInformation("Main window activated.");
-        _ = ShowReleaseNotesAtStartupAsync();
-        _ = CheckForUpdatesAtStartupAsync();
+        CrashBootstrap.RegisterNormalShutdown(() =>
+        {
+            CompleteNormalShutdown();
+            Environment.Exit(0);
+        });
+        MacApplicationTerminationObserver.Register(CompleteNormalShutdown);
+        _startupTask ??= ContinueStartupAsync(builder, args, rootFrame);
+    }
+
+    private async Task ContinueStartupAsync(IApplicationBuilder builder, LaunchActivatedEventArgs args, Frame rootFrame)
+    {
+        try
+        {
+            await WaitForRootAsync(rootFrame);
+
+            var pendingReport = _crashCoordinator.GetUnacknowledgedReports().FirstOrDefault();
+            var showRecovery = !CrashFaultInjection.IsArmed
+                && (pendingReport is not null || _crashCoordinator.IsRecoveryMode);
+            if (showRecovery)
+            {
+                await ShowPendingCrashAtStartupAsync(rootFrame,
+                    pendingReport ?? _crashCoordinator.GetReports().FirstOrDefault());
+                if (!_normalStartupChosen)
+                {
+                    return;
+                }
+            }
+
+            _crashCoordinator.MarkNormalStartupAttempted();
+            Host = builder.Build();
+            Ioc.Default.ConfigureServices(Host.Services);
+            NativeDispatcherFatalLoggerProvider.AttachHost(Host.Services.GetRequiredService<ILoggerFactory>());
+            _crashCoordinator.SetLogger(Host.Services.GetRequiredService<ILogger<CrashCoordinator>>());
+            this.Log().LogInformation("Application host built successfully. LogPath: {LogPath}.", _crashCoordinator.ApplicationLogPath);
+
+            SS = Ioc.Default.GetRequiredService<Services.SettingsService>();
+            SS.LoadData();
+            this.Log().LogInformation("Application settings loaded.");
+
+            var core = Ioc.Default.GetRequiredService<CoreX.Core>();
+            var configuredMinecraftPath = SS.Settings.Minecraft.Path;
+            var startupMinecraftPath = string.IsNullOrWhiteSpace(configuredMinecraftPath)
+                ? new MinecraftPath()
+                : new MinecraftPath(configuredMinecraftPath);
+            core.InitializeLocalAsync(startupMinecraftPath).GetAwaiter().GetResult();
+            if (!_crashCoordinator.IsRecoveryMode)
+            {
+                _ = RunBackgroundStartupTaskAsync(
+                    () => core.RefreshVersionCatalogAsync(),
+                    "Minecraft version catalog refresh");
+            }
+
+            var ac = Ioc.Default.GetRequiredService<CoreX.Services.IAccountService>();
+            _ = RunBackgroundStartupTaskAsync(() => ac.InitializeAsync(), "Account service initialization");
+
+            if (rootFrame.Content is not null && rootFrame.Content is not MainPage)
+            {
+                rootFrame.Content = null;
+            }
+
+            if (rootFrame.Content is null)
+            {
+                rootFrame.Navigate(typeof(MainPage), args.Arguments);
+                this.Log().LogInformation("Navigated to the main page.");
+            }
+
+            MainWindow!.Activate();
+            if (rootFrame.Content is MainPage mainPage)
+            {
+                await mainPage.ShellReady;
+            }
+
+            _crashCoordinator.MarkStartupComplete();
+            CrashFaultInjection.WriteCheckpoint("ShellReady");
+            this.Log().LogInformation("Main shell is ready.");
+            _ = Task.Run(_crashCoordinator.EnrichNativeDiagnostics);
+
+            if (!_crashCoordinator.IsRecoveryMode)
+            {
+                if (!showRecovery)
+                {
+                    await ShowReleaseNotesAtStartupAsync();
+                }
+                await CheckForUpdatesAtStartupAsync();
+            }
+        }
+        catch (Exception exception)
+        {
+            _crashCoordinator.CaptureAndTerminate(exception, "Startup");
+        }
+    }
+
+    private bool _normalStartupChosen;
+
+    private static async Task WaitForRootAsync(FrameworkElement root)
+    {
+        if (root.XamlRoot is not null)
+        {
+            return;
+        }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnLoaded(object sender, RoutedEventArgs args)
+        {
+            root.Loaded -= OnLoaded;
+            completion.TrySetResult();
+        }
+
+        root.Loaded += OnLoaded;
+        if (root.XamlRoot is not null)
+        {
+            root.Loaded -= OnLoaded;
+            completion.TrySetResult();
+        }
+
+        // Loaded is the readiness signal; the timeout is only a degraded-mode
+        // escape hatch for a platform that cannot provide XamlRoot. ContentDialog
+        // will then fail predictably and the inline recovery panel remains usable.
+        await Task.WhenAny(completion.Task, Task.Delay(TimeSpan.FromSeconds(5)));
     }
 
     /// <summary>
@@ -356,8 +468,49 @@ Notes
     /// </summary>
     private void MainWindow_Closed(object sender, WindowEventArgs args)
     {
-        this.Log().LogInformation("Main window is closing. Persisting settings.");
-        SS.SaveData();
+        CompleteNormalShutdown();
+    }
+
+    public void CompleteNormalShutdown()
+    {
+        if (Interlocked.Exchange(ref _normalShutdownStarted, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (SS is not null)
+            {
+                SS.FlushPendingSave();
+            }
+
+            _crashCoordinator.MarkCleanExit();
+        }
+        catch (Exception exception)
+        {
+            _crashCoordinator.CaptureAndTerminate(exception, "Normal shutdown");
+        }
+    }
+
+    private async Task RunBackgroundStartupTaskAsync(Func<Task> operation, string source)
+    {
+        try
+        {
+            await operation();
+        }
+        catch (Exception exception)
+        {
+            _crashCoordinator.ObserveBackgroundFault(exception, source);
+            try
+            {
+                this.Log().LogError(exception, "Background startup operation failed: {Source}.", source);
+            }
+            catch
+            {
+                // Logging is best effort for a recoverable background failure.
+            }
+        }
     }
 
     private async Task ShowReleaseNotesAtStartupAsync()
@@ -373,8 +526,6 @@ Notes
             {
                 return;
             }
-
-            await Task.Yield();
 
             var dialog = CreateReleaseNotesDialog();
             await dialog.ShowAsync();
@@ -453,124 +604,248 @@ Notes
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        e.Handled = true;
-        HandleCrash(e.Exception, "UI UnhandledException");
+        _crashCoordinator.CaptureAndTerminate(e.Exception, "UI.UnhandledException");
     }
 
-    private void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
-    {
-        HandleCrash((Exception)e.ExceptionObject, "AppDomain UnhandledException");
-    }
-
-    private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
-    {
-        e.SetObserved();
-        HandleCrash(e.Exception, "Task UnobservedException");
-    }
-
-    /// <summary>
-    /// Single entry point for all crashes. Writes file FIRST, then shows dialog.
-    /// </summary>
-    private void HandleCrash(Exception exception, string source)
-    {
-        Debug.WriteLine($"[CRASH] Handling crash from {source}: {exception.Message}");
-
-        // 1. Write crash file immediately — before anything else that could fail
-        var crashPath = WriteCrashFile(exception, source);
-
-        // 2. Flush Serilog so buffered logs are persisted
-        try { Log.CloseAndFlush(); } catch { }
-
-        // 3. Show dialog (best effort — crash is already saved)
-        ShowPlatformErrorDialog(
-            $"An unexpected error occurred ({source}).\nCrash report saved to:\n{crashPath}",
-            exception
-        );
-    }
-
-    /// <summary>
-    /// Writes the crash report to disk and records the fatal exception through the configured logger.
-    /// </summary>
-    private string WriteCrashFile(Exception exception, string source)
-    {
-        var crashPath = "unknown";
-        try
-        {
-            crashPath = Path.Combine(
-                DirectResoucres.LocalDataPath,
-                "crashes",
-                $"crash_{DateTime.Now:yyyyMMdd_HHmmss}.txt"
-            );
-            Directory.CreateDirectory(Path.GetDirectoryName(crashPath)!);
-
-            File.WriteAllText(crashPath, BuildCrashReport(exception, source));
-
-            // Also log to Serilog
-            this.Log().LogCritical(exception,
-                "Unhandled exception ({Source}). Platform: {Platform}",
-                source, DirectResoucres.Platform);
-        }
-        catch (Exception writeEx)
-        {
-            // Absolute last resort
-            Debug.WriteLine($"[CRASH WRITE FAILED] {writeEx}");
-            Debug.WriteLine($"[ORIGINAL CRASH] {exception}");
-        }
-        return crashPath;
-    }
-
-    /// <summary>
-    /// Builds the plain-text crash report that is written alongside fatal errors.
-    /// </summary>
-    private static string BuildCrashReport(Exception ex, string source)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("=== CRASH REPORT ===");
-        sb.AppendLine($"Time:     {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
-        sb.AppendLine($"Platform: {DirectResoucres.Platform}");
-        sb.AppendLine($"Source:   {source}");
-        sb.AppendLine();
-        AppendException(sb, ex, 0);
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Appends an exception and its inner exceptions to the crash report text.
-    /// </summary>
-    private static void AppendException(System.Text.StringBuilder sb, Exception? ex, int depth)
-    {
-        if (ex is null) return;
-        var indent = new string(' ', depth * 2);
-        sb.AppendLine($"{indent}--- {(depth == 0 ? "Exception" : "Inner Exception")} ---");
-        sb.AppendLine($"{indent}Type:    {ex.GetType().FullName}");
-        sb.AppendLine($"{indent}Message: {ex.Message}");
-        sb.AppendLine($"{indent}Stack:   {ex.StackTrace}");
-
-        // Recursively unwrap inner exceptions
-        if (ex is AggregateException agg)
-            foreach (var inner in agg.InnerExceptions)
-                AppendException(sb, inner, depth + 1);
-        else
-            AppendException(sb, ex.InnerException, depth + 1);
-    }
-
-    private async void ShowPlatformErrorDialog(string message, Exception ex)
+    private async Task ShowPendingCrashAtStartupAsync(FrameworkElement root, CrashRecord? record)
     {
         try
         {
-            await MessageBox.Show("AppCrash".Localize(), message, Helpers.Enums.MessageBoxButtons.Ok);
+            var openLogsButton = new Button
+            {
+                Content = "OpenCrashLogs".Localize(),
+                HorizontalAlignment = HorizontalAlignment.Left
+            };
+
+            var content = new StackPanel { Spacing = 12 };
+            content.Children.Add(new TextBlock
+            {
+                Text = _crashCoordinator.IsRecoveryMode
+                    ? "RecoveryModeDescription".Localize()
+                    : record?.Kind == CrashRecordKind.UnexpectedShutdown
+                    ? "UnexpectedShutdownDescription".Localize()
+                    : "CrashRecoveryDescription".Localize(),
+                TextWrapping = TextWrapping.WrapWholeWords
+            });
+            content.Children.Add(new TextBlock
+            {
+                Text = record is null ? string.Empty
+                    : $"{record.AppVersion} · {record.Platform} · {record.OccurredUtc.ToLocalTime():g}",
+                TextWrapping = TextWrapping.WrapWholeWords
+            });
+            content.Children.Add(openLogsButton);
+            var details = CreateRecoveryDetails(record);
+            details.Visibility = Visibility.Collapsed;
+            content.Children.Add(details);
+            var status = new TextBlock { TextWrapping = TextWrapping.WrapWholeWords };
+            content.Children.Add(status);
+
+            var dialog = new ContentDialog
+            {
+                Title = (_crashCoordinator.IsRecoveryMode ? "RecoveryMode" : "EmeraldCrashDetected").Localize(),
+                Content = content,
+                PrimaryButtonText = "ViewCrashReport".Localize(),
+                SecondaryButtonText = "ReportToGitHub".Localize(),
+                CloseButtonText = (_crashCoordinator.IsRecoveryMode ? "TryNormalStartup" : "Continue").Localize(),
+                IsPrimaryButtonEnabled = record is not null,
+                IsSecondaryButtonEnabled = record is not null,
+                DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = root.XamlRoot
+            };
+
+            void Acknowledge()
+            {
+                if (record is not null) _crashCoordinator.Acknowledge(record.Id);
+            }
+            void ViewDetails()
+            {
+                Acknowledge();
+                var show = details.Visibility != Visibility.Visible;
+                details.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+                dialog.PrimaryButtonText = (show ? "HideCrashDetails" : "ViewCrashReport").Localize();
+                CrashFaultInjection.WriteCheckpoint("Recovery details viewed");
+            }
+            void ContinueStartup()
+            {
+                Acknowledge();
+                _normalStartupChosen = true;
+            }
+            dialog.PrimaryButtonClick += (_, args) =>
+            {
+                args.Cancel = true;
+                ViewDetails();
+            };
+            dialog.SecondaryButtonClick += async (_, args) =>
+            {
+                args.Cancel = true;
+                Acknowledge();
+                dialog.IsSecondaryButtonEnabled = false;
+                try
+                {
+                    if (record is not null) await ReportCrashOnGitHubAsync(record);
+                }
+                catch (Exception exception)
+                {
+                    status.Text = "CouldNotOpenGitHubReport".Localize();
+                    this.Log().LogWarning(exception, "Could not open GitHub from recovery.");
+                }
+                finally { dialog.IsSecondaryButtonEnabled = record is not null; }
+            };
+            dialog.CloseButtonClick += (_, _) => ContinueStartup();
+            openLogsButton.Click += async (_, _) =>
+            {
+                Acknowledge();
+                try { await OpenCrashLogsAsync(); }
+                catch (Exception exception)
+                {
+                    this.Log().LogWarning(exception, "Could not open logs from recovery.");
+                }
+            };
+            dialog.Opened += (_, _) =>
+            {
+                CrashFaultInjection.WriteCheckpoint($"Recovery dialog opened: {record?.Id ?? "none"}");
+                CrashFaultInjection.ExerciseRecoveryActions(root.DispatcherQueue, ViewDetails, () =>
+                {
+                    ContinueStartup();
+                    dialog.Hide();
+                });
+            };
+
+            await dialog.ShowAsync();
+            // Escape or programmatic cancellation is not a user acknowledgement.
+            // Keep recovery accessible inline instead of presenting another modal.
+            if (!_normalStartupChosen)
+            {
+                await ShowEmergencyRecoveryPanelAsync(root, record);
+            }
         }
-        catch (Exception dialogEx)
+        catch (Exception exception)
         {
-            // Dialog itself failed — log both errors properly
-            this.Log().LogCritical(ex, $"[DIALOG FAILED] {dialogEx}");
-            Debug.WriteLine($"[DIALOG FAILED] {dialogEx}\n[ORIGINAL ERROR] {ex}");
+            this.Log().LogWarning(exception, "Previous-crash recovery dialog failed to open.");
+            await ShowEmergencyRecoveryPanelAsync(root, record);
         }
-        finally
+    }
+
+    private static FrameworkElement CreateRecoveryDetails(CrashRecord? record)
+        => new ScrollViewer
         {
-            // Always kill — crash file is already saved at this point
-            Process.GetCurrentProcess().Kill();
+            MaxHeight = 320,
+            Content = new TextBlock
+            {
+                Text = record is null ? "UnexpectedShutdownDescription".Localize() : CrashReportFormatter.ToText(record),
+                TextWrapping = TextWrapping.WrapWholeWords,
+                IsTextSelectionEnabled = true
+            }
+        };
+
+    private async Task ShowEmergencyRecoveryPanelAsync(FrameworkElement root, CrashRecord? record)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var panel = new StackPanel { Spacing = 12, Padding = new(24) };
+        panel.Children.Add(new TextBlock
+        {
+            Text = record is null ? "RecoveryModeDescription".Localize() : "CrashRecoveryDescription".Localize(),
+            TextWrapping = TextWrapping.WrapWholeWords
+        });
+
+        var viewButton = new Button { Content = "ViewCrashReports".Localize() };
+        var details = CreateRecoveryDetails(record);
+        details.Visibility = Visibility.Collapsed;
+        viewButton.Click += (_, _) =>
+        {
+            if (record is not null)
+            {
+                _crashCoordinator.Acknowledge(record.Id);
+            }
+            details.Visibility = Visibility.Visible;
+        };
+        panel.Children.Add(viewButton);
+        panel.Children.Add(details);
+
+        if (record is not null)
+        {
+            var reportButton = new Button { Content = "ReportToGitHub".Localize() };
+            reportButton.Click += async (_, _) =>
+            {
+                try
+                {
+                    _crashCoordinator.Acknowledge(record.Id);
+                    await ReportCrashOnGitHubAsync(record);
+                }
+                catch (Exception exception)
+                {
+                    this.Log().LogWarning(exception, "Could not report the previous crash from the recovery panel.");
+                }
+            };
+            panel.Children.Add(reportButton);
+
+            var openLogsButton = new Button { Content = "OpenCrashLogs".Localize() };
+            openLogsButton.Click += async (_, _) =>
+            {
+                try
+                {
+                    _crashCoordinator.Acknowledge(record.Id);
+                    await OpenCrashLogsAsync();
+                }
+                catch (Exception exception)
+                {
+                    this.Log().LogWarning(exception, "Could not open logs from the recovery panel.");
+                }
+            };
+            panel.Children.Add(openLogsButton);
         }
+
+        var continueButton = new Button
+        {
+            Content = (_crashCoordinator.IsRecoveryMode ? "TryNormalStartup" : "Continue").Localize()
+        };
+        continueButton.Click += (_, _) =>
+        {
+            if (record is not null) _crashCoordinator.Acknowledge(record.Id);
+            _normalStartupChosen = true;
+            completion.TrySetResult();
+        };
+        panel.Children.Add(continueButton);
+        if (root is Frame frame)
+        {
+            frame.Content = panel;
+        }
+        await completion.Task;
+    }
+
+    private async Task ReportCrashOnGitHubAsync(CrashRecord record)
+    {
+        var draft = new GitHubCrashIssueComposer("https://github.com/RiversideValley/Emerald").Compose(record);
+        try
+        {
+            var package = new DataPackage
+            {
+                RequestedOperation = DataPackageOperation.Copy
+            };
+            package.SetText(draft.FullReport);
+            Clipboard.SetContent(package);
+        }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not copy the crash report to the clipboard.");
+        }
+
+        if (!Uri.TryCreate(draft.Url, UriKind.Absolute, out var uri)
+            || !await Launcher.LaunchUriAsync(uri))
+        {
+            throw new InvalidOperationException("Could not open the GitHub crash draft.");
+        }
+    }
+
+    private Task OpenCrashLogsAsync()
+    {
+        var logsPath = Path.GetDirectoryName(_crashCoordinator.ApplicationLogPath);
+        if (!PlatformFolderLauncher.TryOpen(logsPath))
+        {
+            this.Log().LogWarning("Could not open Emerald application logs at {LogsPath}.", logsPath);
+        }
+
+        return Task.CompletedTask;
     }
 
     #endregion

--- a/Emerald/App.xaml.cs
+++ b/Emerald/App.xaml.cs
@@ -347,7 +347,9 @@ Notes
             CompleteNormalShutdown();
             Environment.Exit(0);
         });
+#if !WINDOWS
         MacApplicationTerminationObserver.Register(CompleteNormalShutdown);
+#endif
         _startupTask ??= ContinueStartupAsync(builder, args, rootFrame);
     }
 

--- a/Emerald/DirectResources.cs
+++ b/Emerald/DirectResources.cs
@@ -1,5 +1,6 @@
 using Emerald.Helpers;
 using Emerald.Models;
+using Emerald.Services;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Windows.UI;
@@ -45,11 +46,63 @@ public static class DirectResoucres
     {
         get
         {
+#if DEBUG
+            // Process-level crash tests must not touch a developer's real profile.
+            if (CrashFaultInjection.IsEnabled)
+            {
+                var testDataRoot = Environment.GetEnvironmentVariable("EMERALD_TEST_DATA_ROOT");
+                if (!string.IsNullOrWhiteSpace(testDataRoot))
+                {
+                    return testDataRoot;
+                }
+            }
+#endif
 #if WINDOWS
             return Windows.Storage.ApplicationData.Current.LocalFolder.Path;
 #else
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Emerald");
 #endif
+        }
+    }
+
+    public static string SafeLocalDataPath
+    {
+        get
+        {
+#if DEBUG
+            if (CrashFaultInjection.IsEnabled)
+            {
+                var testDataRoot = Environment.GetEnvironmentVariable("EMERALD_TEST_DATA_ROOT");
+                if (!string.IsNullOrWhiteSpace(testDataRoot))
+                {
+                    return testDataRoot;
+                }
+            }
+#endif
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(LocalDataPath))
+                {
+                    return LocalDataPath;
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                var localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                if (!string.IsNullOrWhiteSpace(localApplicationData))
+                {
+                    return Path.Combine(localApplicationData, "Emerald");
+                }
+            }
+            catch
+            {
+            }
+
+            return Path.Combine(Path.GetTempPath(), "Emerald");
         }
     }
     public static string BuildType

--- a/Emerald/Emerald.csproj
+++ b/Emerald/Emerald.csproj
@@ -50,6 +50,11 @@
     <DefineConstants>$(DefineConstants);EMERALD_MACOS</DefineConstants>
   </PropertyGroup>
 
+  <!-- Let Uno break first while debugging Desktop unhandled UI exceptions. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' == 'net10.0-desktop'">
+    <BreakOnUnhandledExceptions>true</BreakOnUnhandledExceptions>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(PublishUnsignedPackage)' == 'true' ">
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <AppxBundle>Never</AppxBundle>

--- a/Emerald/Emerald.csproj
+++ b/Emerald/Emerald.csproj
@@ -45,6 +45,11 @@
     </UnoFeatures>
   </PropertyGroup>
 
+  <!-- net10.0-desktop is shared by macOS and Linux, so define this explicitly. -->
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+    <DefineConstants>$(DefineConstants);EMERALD_MACOS</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(PublishUnsignedPackage)' == 'true' ">
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
     <AppxBundle>Never</AppxBundle>

--- a/Emerald/MainPage.xaml.cs
+++ b/Emerald/MainPage.xaml.cs
@@ -14,6 +14,7 @@ using Emerald.CoreX.Notifications;
 using Emerald.CoreX.Services;
 using Emerald.Helpers;
 using Emerald.Models;
+using Emerald.Services;
 using Emerald.Views;
 using Emerald.Views.Settings;
 using Emerald.Views.Store;
@@ -40,6 +41,7 @@ public sealed partial class MainPage : Page
     private readonly HashSet<EAccount> _trackedAccounts = [];
     private readonly Dictionary<string, NotificationType> _notificationTypeSnapshot = new(StringComparer.Ordinal);
     private readonly ObservableCollection<TaskToastItem> _taskToasts = [];
+    private readonly TaskCompletionSource _shellReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private SquareNavigationViewItem? _accountsNavigationItem;
     private SquareNavigationViewItem? _tasksNavigationItem;
@@ -50,6 +52,7 @@ public sealed partial class MainPage : Page
     private bool _isTasksFlyoutOpen;
 
     public ObservableCollection<TaskToastItem> TaskToasts => _taskToasts;
+    public Task ShellReady => _shellReady.Task;
 
     public MainPage()
     {
@@ -240,13 +243,43 @@ public sealed partial class MainPage : Page
 
     private async void MainPage_Loaded(object sender, RoutedEventArgs e)
     {
-        this.Log().LogInformation("Main page loaded.");
-        Emerald.Helpers.WindowManager.SetTitleBar(App.Current.MainWindow, AppTitleBar);
+        try
+        {
+            this.Log().LogInformation("Main page loaded.");
+            Emerald.Helpers.WindowManager.SetTitleBar(App.Current.MainWindow, AppTitleBar);
 
-        InitializeAppearance();
-        InitializeNavView();
-        await LoadAccountsAsync();
-        Loaded -= MainPage_Loaded;
+            if (CrashFaultInjection.IsRequested("MainPage_Loaded")
+                || CrashFaultInjection.IsRequested("MainPage_Loaded_BeforeAwait"))
+            {
+                throw new NotImplementedException("Intentional MainPage crash test.");
+            }
+
+            InitializeAppearance();
+            InitializeNavView();
+            await LoadAccountsAsync();
+            if (CrashFaultInjection.IsRequested("MainPage_Loaded_AfterAwait"))
+            {
+                throw new NotImplementedException("Intentional post-await MainPage crash test.");
+            }
+
+            if (CrashFaultInjection.IsRequested("DispatcherCallback"))
+            {
+                if (!DispatcherQueue.TryEnqueue(() => throw new NotImplementedException("Intentional dispatcher crash test.")))
+                {
+                    throw new InvalidOperationException("Could not enqueue the requested dispatcher crash test.");
+                }
+            }
+
+            CrashFaultInjection.ExerciseAdditionalPaths(DispatcherQueue, this.Log());
+
+            Loaded -= MainPage_Loaded;
+            _shellReady.TrySetResult();
+        }
+        catch (Exception exception)
+        {
+            _shellReady.TrySetException(exception);
+            App.Current.CrashCoordinator.CaptureAndTerminate(exception, "MainPage.Loaded");
+        }
     }
 
     /// <summary>
@@ -288,6 +321,26 @@ public sealed partial class MainPage : Page
         this.Log().LogInformation("Navigating to tag {Tag}.", tag);
         NavView.SelectedItem = target;
         Navigate(target, parameter);
+    }
+
+    public void NavigateToCrashReports(string? reportId)
+    {
+        var items = NavView.MenuItems.Cast<object>().Concat(NavView.FooterMenuItems.Cast<object>());
+        var target = items
+            .OfType<SquareNavigationViewItem>()
+            .FirstOrDefault(item => string.Equals(item.Tag as string, "Settings", StringComparison.OrdinalIgnoreCase));
+
+        if (target is null)
+        {
+            this.Log().LogWarning("Could not navigate to crash reports because Settings navigation is unavailable.");
+            return;
+        }
+
+        HideTasksFlyout();
+        NavView.SelectedItem = target;
+        _lastNonTaskNavigationItem = target;
+        NavigateOnce(typeof(SettingsPage), new CrashReportsNavigationRequest(reportId), forceNavigate: true);
+        UpdateHeader(target);
     }
 
     /// <summary>

--- a/Emerald/Platforms/Desktop/MacApplicationTerminationObserver.cs
+++ b/Emerald/Platforms/Desktop/MacApplicationTerminationObserver.cs
@@ -1,0 +1,122 @@
+using System.Runtime.InteropServices;
+
+namespace Emerald;
+
+/// <summary>
+/// Observes AppKit's normal termination notification without replacing Uno's
+/// NSApplication delegate. Sudden termination does not send this notification,
+/// so the lifecycle marker remains unclean in that case.
+/// </summary>
+internal static class MacApplicationTerminationObserver
+{
+    private const string NotificationName = "NSApplicationWillTerminateNotification";
+    private static readonly object Gate = new();
+    private static readonly NotificationCallback Callback = OnNotification;
+    private static Action? _onTerminate;
+    private static IntPtr _observer;
+
+    public static void Register(Action onTerminate)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        lock (Gate)
+        {
+            _onTerminate = onTerminate;
+            if (_observer != IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                var observerClass = objc_getClass("EmeraldTerminationObserver");
+                if (observerClass == IntPtr.Zero)
+                {
+                    observerClass = objc_allocateClassPair(objc_getClass("NSObject"), "EmeraldTerminationObserver", IntPtr.Zero);
+                    if (observerClass == IntPtr.Zero)
+                    {
+                        return;
+                    }
+
+                    class_addMethod(
+                        observerClass,
+                        sel_registerName("emeraldWillTerminate:"),
+                        Marshal.GetFunctionPointerForDelegate(Callback),
+                        "v@:@");
+                    objc_registerClassPair(observerClass);
+                }
+
+                _observer = objc_msgSend(observerClass, sel_registerName("new"));
+                var center = objc_msgSend(objc_getClass("NSNotificationCenter"), sel_registerName("defaultCenter"));
+                var notificationName = CreateNSString(NotificationName);
+                objc_msgSend(
+                    center,
+                    sel_registerName("addObserver:selector:name:object:"),
+                    _observer,
+                    sel_registerName("emeraldWillTerminate:"),
+                    notificationName,
+                    IntPtr.Zero);
+            }
+            catch
+            {
+                _observer = IntPtr.Zero;
+            }
+        }
+    }
+
+    private static void OnNotification(IntPtr self, IntPtr selector, IntPtr notification)
+    {
+        try
+        {
+            _onTerminate?.Invoke();
+        }
+        catch
+        {
+            // Never allow an exception to cross the Objective-C callback boundary.
+        }
+    }
+
+    private static IntPtr CreateNSString(string value)
+    {
+        var utf8 = Marshal.StringToCoTaskMemUTF8(value);
+        try
+        {
+            return objc_msgSend(objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), utf8);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(utf8);
+        }
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void NotificationCallback(IntPtr self, IntPtr selector, IntPtr notification);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr objc_getClass([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr objc_allocateClassPair(IntPtr superclass, [MarshalAs(UnmanagedType.LPStr)] string name, IntPtr extraBytes);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static extern bool class_addMethod(IntPtr cls, IntPtr selector, IntPtr implementation, [MarshalAs(UnmanagedType.LPStr)] string types);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void objc_registerClassPair(IntPtr cls);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr sel_registerName([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1);
+
+    [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4);
+}

--- a/Emerald/Platforms/Desktop/MacApplicationTerminationObserver.cs
+++ b/Emerald/Platforms/Desktop/MacApplicationTerminationObserver.cs
@@ -1,3 +1,4 @@
+#if EMERALD_MACOS
 using System.Runtime.InteropServices;
 
 namespace Emerald;
@@ -120,3 +121,4 @@ internal static class MacApplicationTerminationObserver
     [DllImport("/usr/lib/libobjc.A.dylib", CallingConvention = CallingConvention.Cdecl, EntryPoint = "objc_msgSend")]
     private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4);
 }
+#endif

--- a/Emerald/Platforms/Desktop/Program.cs
+++ b/Emerald/Platforms/Desktop/Program.cs
@@ -1,4 +1,5 @@
 using Uno.UI.Hosting;
+using Emerald.Services;
 
 namespace Emerald;
 public class Program
@@ -6,14 +7,31 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        var host = UnoPlatformHostBuilder.Create()
-            .App(() => new App())
-            .UseX11()
-            .UseLinuxFrameBuffer()
-            .UseMacOS()
-            .UseWin32()
-            .Build();
+        CrashFaultInjection.ConfigureFromArguments(args);
+        var crashCoordinator = CrashBootstrap.Initialize();
+        try
+        {
+#if DEBUG
+            if (CrashFaultInjection.IsRequested("DesktopHost"))
+            {
+                throw new NotImplementedException("Intentional desktop-host crash test.");
+            }
+#endif
 
-        host.Run();
+            var host = UnoPlatformHostBuilder.Create()
+                .App(() => new App())
+                .UseX11()
+                .UseLinuxFrameBuffer()
+                .UseMacOS()
+                .UseWin32()
+                .Build();
+
+            host.Run();
+            CrashBootstrap.RequestNormalShutdown();
+        }
+        catch (Exception exception)
+        {
+            crashCoordinator.CaptureAndTerminate(exception, "Desktop host");
+        }
     }
 }

--- a/Emerald/Properties/launchSettings.json
+++ b/Emerald/Properties/launchSettings.json
@@ -15,17 +15,66 @@
     },
     "Emerald (WinAppSDK Packaged)": {
       "commandName": "MsixPackage",
-      "compatibleTargetFramework": "windows"
+      "compatibleTargetFramework": "windows",
+      "commandLineArgs": "--emerald-test=0"
+    },
+    "Crash - MainPage (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows",
+      "commandLineArgs": "--emerald-test=1 --emerald-test-crash=MainPage_Loaded --emerald-test-disable-studio=1"
+    },
+    "Crash - Dispatcher (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows",
+      "commandLineArgs": "--emerald-test=1 --emerald-test-crash=DispatcherCallback --emerald-test-disable-studio=1"
+    },
+    "Crash - Startup (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows",
+      "commandLineArgs": "--emerald-test=1 --emerald-test-crash=WinAppStartup --emerald-test-disable-studio=1"
     },
     "Emerald (Desktop)": {
       "commandName": "Project",
-      "compatibleTargetFramework": "desktop"
+      "compatibleTargetFramework": "desktop",
+      "environmentVariables": {
+        "EMERALD_TEST": "0"
+      }
     },
     "Emerald (Desktop WSL2)": {
       "commandName": "WSL2",
       "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/Emerald.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
+    },
+    "Crash - MainPage": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "desktop",
+      "environmentVariables": {
+        "EMERALD_TEST": "1",
+        "EMERALD_TEST_DATA_ROOT": "",
+        "EMERALD_TEST_CRASH": "MainPage_Loaded",
+        "EMERALD_TEST_DISABLE_STUDIO": "1"
+      }
+    },
+    "Crash - Dispatcher": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "desktop",
+      "environmentVariables": {
+        "EMERALD_TEST": "1",
+        "EMERALD_TEST_DATA_ROOT": "",
+        "EMERALD_TEST_CRASH": "DispatcherCallback",
+        "EMERALD_TEST_DISABLE_STUDIO": "1"
+      }
+    },
+    "Crash - DesktopHost": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "desktop",
+      "environmentVariables": {
+        "EMERALD_TEST": "1",
+        "EMERALD_TEST_DATA_ROOT": "",
+        "EMERALD_TEST_CRASH": "DesktopHost",
+        "EMERALD_TEST_DISABLE_STUDIO": "1"
+      }
     }
   }
 }

--- a/Emerald/Services/AppUpdateService.cs
+++ b/Emerald/Services/AppUpdateService.cs
@@ -353,7 +353,7 @@ public partial class AppUpdateService(ILogger<AppUpdateService> logger) : IAppUp
         _ = Task.Run(async () =>
         {
             await Task.Delay(500);
-            Process.GetCurrentProcess().Kill();
+            CrashBootstrap.RequestNormalShutdown();
         });
     }
 #endif

--- a/Emerald/Services/CrashCoordinator.cs
+++ b/Emerald/Services/CrashCoordinator.cs
@@ -1,0 +1,452 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Emerald.CoreX.CrashHandling;
+using Microsoft.Extensions.Logging;
+
+namespace Emerald.Services;
+
+public sealed class CrashCoordinator
+{
+    private readonly ICrashReportStore _store;
+    private readonly IAppLifecycleTracker _lifecycle;
+    private readonly IPlatformDiagnosticsProvider _platformDiagnostics;
+    private readonly CrashEnvironment _environment;
+    private readonly string _applicationLogPath;
+    private readonly IProcessTerminator _processTerminator;
+    private readonly object _startGate = new();
+    private int _fatalCaptureStarted;
+    private int _fatalCaptureCompleted;
+    private int _fatalTerminationRequested;
+    private int _fatalTerminationStarted;
+    private CrashRecord? _capturedRecord;
+    private int _processHandlersRegistered;
+    private LifecycleStartResult? _startResult;
+    private ILogger<CrashCoordinator>? _logger;
+
+    public CrashCoordinator(
+        ICrashReportStore store,
+        IAppLifecycleTracker lifecycle,
+        IPlatformDiagnosticsProvider platformDiagnostics,
+        CrashEnvironment environment,
+        string applicationLogPath,
+        IProcessTerminator? processTerminator = null)
+    {
+        _store = store;
+        _lifecycle = lifecycle;
+        _platformDiagnostics = platformDiagnostics;
+        _environment = environment;
+        _applicationLogPath = applicationLogPath;
+        _processTerminator = processTerminator ?? new EnvironmentProcessTerminator();
+    }
+
+    public ICrashReportStore Store => _store;
+    public string ReportsPath => _store.ReportsPath;
+    public string ApplicationLogPath => _applicationLogPath;
+    public string CurrentRunId => _lifecycle.CurrentRunId;
+    public bool IsRecoveryMode => _startResult?.IsRecoveryMode == true;
+    public bool HasPreviousUnexpectedRun => _startResult?.PreviousRun is not null;
+
+    public void SetLogger(ILogger<CrashCoordinator> logger)
+        => _logger = logger;
+
+    public void RegisterProcessHandlers()
+    {
+        if (Interlocked.Exchange(ref _processHandlersRegistered, 1) != 0)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+    }
+
+    public void BeginRun()
+    {
+        lock (_startGate)
+        {
+            if (_startResult is not null)
+            {
+                return;
+            }
+
+            using var startResult = _lifecycle.BeginRun();
+            _startResult = startResult;
+            foreach (var previousRun in startResult.PreviousRuns)
+            {
+                if (previousRun.CleanShutdown)
+                {
+                    _lifecycle.MarkRunReconciled(previousRun.RunId);
+                    continue;
+                }
+
+                if (_store.HasReportForRun(previousRun.RunId))
+                {
+                    _lifecycle.MarkRunReconciled(previousRun.RunId);
+                    continue;
+                }
+
+                var record = CrashRecord.CreateUnexpectedShutdown(
+                    previousRun,
+                    _environment,
+                    CrashLogTailReader.Read(_applicationLogPath));
+                if (_store.TryWrite(record))
+                {
+                    _lifecycle.MarkRunReconciled(previousRun.RunId);
+                }
+            }
+        }
+    }
+
+    public CrashRecord? CaptureManaged(Exception? exception, string source)
+    {
+        if (Interlocked.Exchange(ref _fatalCaptureStarted, 1) != 0)
+        {
+            return _capturedRecord;
+        }
+
+        try
+        {
+            _lifecycle.MarkFatalFailure();
+            var occurredUtc = DateTimeOffset.UtcNow;
+            var record = new CrashRecord
+            {
+                RunId = CurrentRunId,
+                OccurredUtc = occurredUtc,
+                Kind = CrashRecordKind.ManagedCrash,
+                Source = source,
+                AppVersion = _environment.AppVersion,
+                PackageVersion = _environment.PackageVersion,
+                BuildChannel = _environment.BuildChannel,
+                ReleaseTag = _environment.ReleaseTag,
+                CommitSha = _environment.CommitSha,
+                BuildTimestampUtc = _environment.BuildTimestampUtc,
+                Platform = _environment.Platform,
+                OperatingSystem = _environment.OperatingSystem,
+                Architecture = _environment.Architecture,
+                Runtime = _environment.Runtime,
+                Exception = exception is null ? null : CrashExceptionInfo.FromException(exception),
+                ApplicationLogTail = CrashLogTailReader.Read(_applicationLogPath),
+                NativeDiagnosticsStatus = "Pending next launch"
+            };
+
+            if (!_store.TryWriteFatal(record))
+            {
+                Debug.WriteLine($"[CRASH WRITE FAILED] {source}: {exception}");
+            }
+
+            try
+            {
+                _logger?.LogCritical(exception, "Captured fatal Emerald exception from {Source}.", source);
+            }
+            catch
+            {
+                // The report is already persisted; logging must not interfere with termination.
+            }
+
+            _capturedRecord = record;
+            return record;
+        }
+        catch (Exception captureException)
+        {
+            Debug.WriteLine($"[CRASH CAPTURE FAILED] {source}: {captureException}");
+            return null;
+        }
+        finally
+        {
+            Volatile.Write(ref _fatalCaptureCompleted, 1);
+            TerminateAfterCaptureIfRequested();
+        }
+    }
+
+    public void ObserveBackgroundFault(Exception exception, string source)
+    {
+        try
+        {
+            _logger?.LogError(exception, "Observed background task failure from {Source}.", source);
+            Debug.WriteLine($"[BACKGROUND TASK FAILURE] {source}: {exception}");
+        }
+        catch
+        {
+            // An ILogger provider is application code too; it must not turn a
+            // recoverable background fault into an unhandled exception.
+        }
+    }
+
+    public IReadOnlyList<CrashRecord> GetReports()
+        => _store.GetAll();
+
+    public IReadOnlyList<CrashRecord> GetUnacknowledgedReports()
+        => _store.GetAll().Where(record => !record.IsAcknowledged).ToArray();
+
+    public bool Acknowledge(string id)
+        => _store.TryAcknowledge(id);
+
+    public bool Delete(string id)
+        => _store.TryDelete(id);
+
+    public int DeleteAll()
+        => _store.DeleteAll();
+
+    public void EnrichNativeDiagnostics()
+    {
+        foreach (var record in GetReports().Where(report =>
+                     string.Equals(report.NativeDiagnosticsStatus, "Pending next launch", StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(report.NativeDiagnosticsStatus, "Unavailable", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var diagnostics = _platformDiagnostics.FindRecent(record.OccurredUtc);
+                record.NativeDiagnosticsStatus = diagnostics.Status;
+                record.NativeDiagnosticsPath = diagnostics.Path;
+                _store.TryWrite(record);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    public void MarkStartupComplete()
+        => _lifecycle.MarkStartupComplete();
+
+    public void MarkNormalStartupAttempted()
+        => _lifecycle.MarkNormalStartupAttempted();
+
+    public void MarkCleanExit()
+        => _lifecycle.MarkCleanExit();
+
+    public void CaptureAndTerminate(Exception? exception, string source)
+    {
+        Interlocked.Exchange(ref _fatalTerminationRequested, 1);
+        CaptureManaged(exception, source);
+        TerminateAfterCaptureIfRequested();
+    }
+
+    private void TerminateAfterCaptureIfRequested()
+    {
+        // A competing callback requests termination without interrupting the
+        // winning writer. That writer terminates in its finally block, including
+        // when persistence fails. Capture-only notifications remain capture-only.
+        if (Volatile.Read(ref _fatalCaptureCompleted) == 0
+            || Volatile.Read(ref _fatalTerminationRequested) == 0
+            || Interlocked.Exchange(ref _fatalTerminationStarted, 1) != 0)
+        {
+            return;
+        }
+
+        _processTerminator.TerminateFatal(_capturedRecord?.Id ?? "unavailable");
+    }
+
+    private void CurrentDomain_UnhandledException(object? sender, System.UnhandledExceptionEventArgs e)
+    {
+        Exception exception;
+        if (e.ExceptionObject is Exception typedException)
+        {
+            exception = typedException;
+        }
+        else
+        {
+            string description;
+            try
+            {
+                description = Convert.ToString(e.ExceptionObject) ?? "Unknown unhandled exception object.";
+            }
+            catch
+            {
+                description = "Unknown unhandled exception object.";
+            }
+
+            exception = new Exception(description);
+        }
+
+        CaptureManaged(exception, "AppDomain.UnhandledException");
+    }
+
+    private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        e.SetObserved();
+        ObserveBackgroundFault(e.Exception, "TaskScheduler.UnobservedTaskException");
+        CrashFaultInjection.WriteCheckpoint("Unobserved task observed");
+    }
+}
+
+public interface IProcessTerminator
+{
+    void TerminateFatal(string reportId);
+}
+
+public sealed class EnvironmentProcessTerminator : IProcessTerminator
+{
+    public void TerminateFatal(string reportId)
+        => Environment.FailFast($"Emerald terminated after an unrecoverable failure. Report: {reportId}");
+}
+
+public static class CrashBootstrap
+{
+    private static readonly object Gate = new();
+    private static CrashCoordinator? _current;
+    private static Action? _normalShutdown;
+
+    public static CrashCoordinator Current
+    {
+        get
+        {
+            lock (Gate)
+            {
+                return _current ??= Create();
+            }
+        }
+    }
+
+    public static CrashCoordinator Initialize()
+    {
+        var current = Current;
+        try
+        {
+            NativeDispatcherFatalLoggerProvider.InstallEarly(current);
+            current.RegisterProcessHandlers();
+            current.BeginRun();
+        }
+        catch (Exception exception)
+        {
+            // Bootstrap must not prevent the application from reaching its own
+            // fatal policy when a platform event hookup is unavailable.
+            Debug.WriteLine($"[CRASH BOOTSTRAP FAILED] {exception}");
+        }
+
+        return current;
+    }
+
+    public static void RegisterNormalShutdown(Action shutdown)
+        => Interlocked.Exchange(ref _normalShutdown, shutdown);
+
+    public static void RequestNormalShutdown()
+    {
+        if (_normalShutdown is not null)
+        {
+            _normalShutdown();
+            return;
+        }
+
+        Environment.Exit(0);
+    }
+
+    private static CrashCoordinator Create()
+    {
+        try
+        {
+            var localDataPath = ResolveCrashDataPath();
+            var environment = new CrashEnvironment(
+                DirectResoucres.PublicVersion,
+                DirectResoucres.PackageVersion,
+                DirectResoucres.ReleaseChannel.ToString(),
+                DirectResoucres.ReleaseTag,
+                DirectResoucres.CommitSha,
+                DirectResoucres.BuildTimestampUtc,
+                DirectResoucres.Platform,
+                RuntimeInformation.OSDescription,
+                RuntimeInformation.ProcessArchitecture.ToString(),
+                RuntimeInformation.FrameworkDescription);
+
+            var fallbackDataPath = ResolveFallbackCrashDataPath(localDataPath);
+            return new CrashCoordinator(
+                new FallbackCrashReportStore(
+                    new FileCrashReportStore(localDataPath),
+                    new FileCrashReportStore(fallbackDataPath)),
+                new FileAppLifecycleTracker(localDataPath, environment),
+                new PlatformDiagnosticsProvider(),
+                environment,
+                Path.Combine(localDataPath, "logs", "app_.log"));
+        }
+        catch (Exception exception)
+        {
+            Debug.WriteLine($"[CRASH COORDINATOR CREATE FAILED] {exception}");
+            var emergencyPath = Path.Combine(Path.GetTempPath(), "Emerald");
+            var environment = new CrashEnvironment(
+                "unknown",
+                "unknown",
+                "unknown",
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                "unknown",
+                RuntimeInformation.OSDescription,
+                RuntimeInformation.ProcessArchitecture.ToString(),
+                RuntimeInformation.FrameworkDescription);
+            return new CrashCoordinator(
+                new FileCrashReportStore(emergencyPath),
+                new FileAppLifecycleTracker(emergencyPath, environment),
+                new PlatformDiagnosticsProvider(),
+                environment,
+                Path.Combine(emergencyPath, "logs", "app_.log"));
+        }
+    }
+
+    private static string ResolveCrashDataPath()
+    {
+        // Test sessions must never discover or modify the real profile's reports.
+        if (!string.IsNullOrWhiteSpace(CrashFaultInjection.DataRoot))
+        {
+            return Path.GetFullPath(CrashFaultInjection.DataRoot);
+        }
+
+        var candidates = new List<string>();
+        try { candidates.Add(DirectResoucres.LocalDataPath); } catch { }
+        try
+        {
+            var localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrWhiteSpace(localApplicationData))
+            {
+                candidates.Add(Path.Combine(localApplicationData, "Emerald"));
+            }
+        }
+        catch { }
+
+        candidates.Add(Path.Combine(Path.GetTempPath(), "Emerald"));
+        foreach (var candidate in candidates.Where(path => !string.IsNullOrWhiteSpace(path)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            try
+            {
+                Directory.CreateDirectory(candidate);
+                var probe = Path.Combine(candidate, ".crash-write-probe");
+                using (var stream = new FileStream(probe, FileMode.Create, FileAccess.Write, FileShare.Read, 1, FileOptions.WriteThrough))
+                {
+                    stream.WriteByte(1);
+                    stream.Flush(true);
+                }
+                File.Delete(probe);
+                return candidate;
+            }
+            catch { }
+        }
+
+        return Path.Combine(Path.GetTempPath(), "Emerald");
+    }
+
+    private static string ResolveFallbackCrashDataPath(string primaryPath)
+    {
+        if (!string.IsNullOrWhiteSpace(CrashFaultInjection.DataRoot))
+        {
+            return Path.Combine(primaryPath, "diagnostics-fallback");
+        }
+
+        try
+        {
+            var localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var fallback = string.IsNullOrWhiteSpace(localApplicationData)
+                ? string.Empty
+                : Path.Combine(localApplicationData, "Emerald");
+            if (!string.IsNullOrWhiteSpace(fallback)
+                && !string.Equals(fallback, primaryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return fallback;
+            }
+        }
+        catch
+        {
+        }
+
+        return Path.Combine(Path.GetTempPath(), "Emerald");
+    }
+}

--- a/Emerald/Services/CrashFaultInjection.cs
+++ b/Emerald/Services/CrashFaultInjection.cs
@@ -147,6 +147,14 @@ internal static class CrashFaultInjection
                 CrashBootstrap.Current.CaptureAndTerminate(exception, "Capture-then-terminate test");
             }
         }
+        else if (IsRequested("UnoApplicationUnhandled"))
+        {
+            // Exercises Emerald's event-policy callback. Framework delivery itself is
+            // validated manually because Uno's Desktop dispatcher logs this path in
+            // the pinned runtime rather than raising Application.UnhandledException.
+            App.Current.HandleUnoUnhandledException(
+                new NotImplementedException("Intentional Uno application-unhandled test."));
+        }
         else if (IsRequested("OrdinaryError"))
         {
             logger.LogError(new NotImplementedException("Intentional recoverable test error."), "Ordinary error test");

--- a/Emerald/Services/CrashFaultInjection.cs
+++ b/Emerald/Services/CrashFaultInjection.cs
@@ -1,0 +1,240 @@
+namespace Emerald.Services;
+
+/// <summary>
+/// Development-only fault injection, once per process. A crash profile is rearmed
+/// on every launch. Normal Desktop startup does not arm another fault.
+/// </summary>
+internal static class CrashFaultInjection
+{
+    private static int _fired;
+    private static int _argumentTestMode = -1;
+    private static int _argumentDataRootConfigured;
+    private static int _argumentDisableStudio;
+    private static string? _argumentCrashPoint;
+    private static string? _argumentDataRoot;
+    private static string? _argumentRecoveryAction;
+
+    public static string? DataRoot
+    {
+        get
+        {
+            if (!IsEnabled) return null;
+            return Volatile.Read(ref _argumentDataRootConfigured) == 1
+                ? Volatile.Read(ref _argumentDataRoot)
+                : Environment.GetEnvironmentVariable("EMERALD_TEST_DATA_ROOT");
+        }
+    }
+
+    public static bool IsArmed => IsEnabled
+        && !string.IsNullOrWhiteSpace(GetCrashPoint());
+
+    public static bool DisableStudio => IsEnabled
+        && (Volatile.Read(ref _argumentDisableStudio) == 1
+            || string.Equals(Environment.GetEnvironmentVariable("EMERALD_TEST_DISABLE_STUDIO"), "1", StringComparison.Ordinal));
+
+    public static bool IsEnabled
+    {
+        get
+        {
+#if DEBUG
+            var argumentMode = Volatile.Read(ref _argumentTestMode);
+            if (argumentMode >= 0)
+            {
+                return argumentMode == 1;
+            }
+
+            return string.Equals(
+                Environment.GetEnvironmentVariable("EMERALD_TEST"),
+                "1",
+                StringComparison.Ordinal);
+#else
+            return false;
+#endif
+        }
+    }
+
+    /// <summary>
+    /// Reads Debug-only test options from process or packaged activation arguments.
+    /// Packaged WinAppSDK launch profiles do not reliably receive launchSettings
+    /// environment variables, so they use the same explicit gate as the environment
+    /// flow via --emerald-test=1.
+    /// </summary>
+    public static void ConfigureFromArguments(IEnumerable<string> arguments)
+    {
+#if DEBUG
+        foreach (var argument in arguments)
+        {
+            if (TryReadOption(argument, "--emerald-test", out var testMode))
+            {
+                Volatile.Write(ref _argumentTestMode, string.Equals(testMode, "1", StringComparison.Ordinal) ? 1 : 0);
+            }
+            else if (TryReadOption(argument, "--emerald-test-crash", out var crashPoint))
+            {
+                Volatile.Write(ref _argumentCrashPoint, crashPoint);
+            }
+            else if (TryReadOption(argument, "--emerald-test-data-root", out var dataRoot))
+            {
+                Volatile.Write(ref _argumentDataRoot, dataRoot);
+                Volatile.Write(ref _argumentDataRootConfigured, 1);
+            }
+            else if (TryReadOption(argument, "--emerald-test-disable-studio", out var disableStudio))
+            {
+                Volatile.Write(ref _argumentDisableStudio, string.Equals(disableStudio, "1", StringComparison.Ordinal) ? 1 : 0);
+            }
+            else if (TryReadOption(argument, "--emerald-test-recovery-action", out var recoveryAction))
+            {
+                Volatile.Write(ref _argumentRecoveryAction, recoveryAction);
+            }
+        }
+#endif
+    }
+
+    public static void ConfigureFromActivationArguments(string? arguments)
+    {
+#if DEBUG
+        if (string.IsNullOrWhiteSpace(arguments)) return;
+        ConfigureFromArguments(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+#endif
+    }
+
+    public static bool IsRequested(string point)
+    {
+#if DEBUG
+        if (!IsArmed
+            || !string.Equals(GetCrashPoint(), point, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (Interlocked.Exchange(ref _fired, 1) != 0)
+        {
+            return false;
+        }
+
+        WriteCheckpoint($"Firing {point}");
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static void ExerciseAdditionalPaths(Microsoft.UI.Dispatching.DispatcherQueue queue,
+        Microsoft.Extensions.Logging.ILogger logger)
+    {
+#if DEBUG
+        if (IsRequested("AsyncVoidBeforeAwait"))
+        {
+            queue.TryEnqueue(() => ThrowAsyncVoid(afterAwait: false));
+        }
+        else if (IsRequested("AsyncVoidAfterAwait"))
+        {
+            queue.TryEnqueue(() => ThrowAsyncVoid(afterAwait: true));
+        }
+        else if (IsRequested("WorkerThread"))
+        {
+            new Thread(() => throw new NotImplementedException("Intentional worker-thread crash test.")).Start();
+        }
+        else if (IsRequested("CaptureThenTerminate"))
+        {
+            try
+            {
+                throw new NotImplementedException("Intentional capture-then-terminate crash test.");
+            }
+            catch (Exception exception)
+            {
+                CrashBootstrap.Current.CaptureManaged(exception, "Capture-then-terminate test");
+                CrashBootstrap.Current.CaptureAndTerminate(exception, "Capture-then-terminate test");
+            }
+        }
+        else if (IsRequested("OrdinaryError"))
+        {
+            logger.LogError(new NotImplementedException("Intentional recoverable test error."), "Ordinary error test");
+            WriteCheckpoint("Ordinary error logged");
+        }
+        else if (IsRequested("UnobservedTask"))
+        {
+            _ = CollectUnobservedTaskAsync();
+        }
+#endif
+    }
+
+#if DEBUG
+    private static async void ThrowAsyncVoid(bool afterAwait)
+    {
+        if (!afterAwait)
+        {
+            throw new NotImplementedException("Intentional async-void before-await crash test.");
+        }
+
+        await Task.Delay(20);
+        throw new NotImplementedException("Intentional async-void after-await crash test.");
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference CreateUnobservedTask()
+    {
+        var task = Task.Run(() => throw new NotImplementedException("Intentional unobserved task test."));
+        SpinWait.SpinUntil(() => task.IsCompleted);
+        return new WeakReference(task);
+    }
+
+    private static async Task CollectUnobservedTaskAsync()
+    {
+        var task = CreateUnobservedTask();
+        for (var attempt = 0; attempt < 20 && task.IsAlive; attempt++)
+        {
+            await Task.Delay(50);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+#endif
+
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static void ExerciseRecoveryActions(Microsoft.UI.Dispatching.DispatcherQueue queue,
+        Action viewDetails, Action continueStartup)
+    {
+#if DEBUG
+        // Automated UI actions are allowed only in an explicitly isolated test run.
+        if (string.IsNullOrWhiteSpace(DataRoot)) return;
+        var action = Volatile.Read(ref _argumentRecoveryAction)
+            ?? Environment.GetEnvironmentVariable("EMERALD_TEST_RECOVERY_ACTION");
+        if (action != "view-continue" && action != "continue") return;
+        queue.TryEnqueue(() =>
+        {
+            if (action == "view-continue") viewDetails();
+            queue.TryEnqueue(() => continueStartup());
+        });
+#endif
+    }
+
+    [System.Diagnostics.Conditional("DEBUG")]
+    public static void WriteCheckpoint(string checkpoint)
+    {
+        if (IsEnabled)
+        {
+            try { Console.Error.WriteLine($"[EMERALD TEST] {checkpoint}"); } catch { }
+        }
+    }
+
+#if DEBUG
+    private static string? GetCrashPoint() => Volatile.Read(ref _argumentCrashPoint)
+        ?? Environment.GetEnvironmentVariable("EMERALD_TEST_CRASH");
+
+    private static bool TryReadOption(string argument, string name, out string value)
+    {
+        var prefix = name + "=";
+        if (argument.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            value = argument[prefix.Length..].Trim('"');
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+#else
+    private static string? GetCrashPoint() => null;
+#endif
+}

--- a/Emerald/Services/NativeDispatcherFatalLoggerProvider.cs
+++ b/Emerald/Services/NativeDispatcherFatalLoggerProvider.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Emerald.Services;
+
+/// <summary>
+/// Uno 6.6.184 catches exceptions raised by queued callbacks and reports them only
+/// through its logger. This narrow adapter turns that one known message back into
+/// Emerald's fatal policy while leaving all other framework logs unchanged.
+/// </summary>
+internal sealed class NativeDispatcherFatalLoggerProvider(CrashCoordinator coordinator) : ILoggerProvider
+{
+    private static readonly object EarlyFactoryGate = new();
+    private static BridgeLoggerFactory? _earlyFactory;
+
+    /// <summary>
+    /// Uno can cache its NativeDispatcher logger before the application host is
+    /// built. Install a tiny early factory so that the pinned dispatcher bridge is
+    /// present during that window. Cached loggers stay attached to this factory;
+    /// the host is connected as a forwarding destination after Build().
+    /// </summary>
+    public static void InstallEarly(CrashCoordinator coordinator)
+    {
+        lock (EarlyFactoryGate)
+        {
+            if (_earlyFactory is not null)
+            {
+                return;
+            }
+
+            _earlyFactory = new BridgeLoggerFactory(coordinator);
+            Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = _earlyFactory;
+            // Uno.Foundation.Logging has its own adapter and caches loggers.
+            // Setting AmbientLoggerFactory alone leaves framework loggers null.
+            Uno.UI.Adapter.Microsoft.Extensions.Logging.LoggingAdapter.Initialize();
+        }
+    }
+
+    public static void AttachHost(ILoggerFactory hostFactory)
+    {
+        lock (EarlyFactoryGate)
+        {
+            if (_earlyFactory is null)
+            {
+                throw new InvalidOperationException("The early crash logger must be installed before the host.");
+            }
+
+            _earlyFactory.AttachHost(hostFactory);
+            Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = _earlyFactory;
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => string.Equals(categoryName, "Uno.UI.Dispatching.NativeDispatcher", StringComparison.Ordinal)
+            ? new NativeDispatcherLogger(coordinator)
+            : NullLogger.Instance;
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class BridgeLoggerFactory(CrashCoordinator coordinator) : ILoggerFactory
+    {
+        private readonly NativeDispatcherFatalLoggerProvider _fatalProvider = new(coordinator);
+        private ILoggerFactory? _host;
+
+        public void AttachHost(ILoggerFactory host) => Volatile.Write(ref _host, host);
+        public ILogger CreateLogger(string categoryName)
+            => new BridgeLogger(this, categoryName, _fatalProvider.CreateLogger(categoryName));
+        public void AddProvider(ILoggerProvider provider) => Volatile.Read(ref _host)?.AddProvider(provider);
+        public void Dispose() { } // The host owns its own lifetime; this bridge is process-wide.
+
+        private sealed class BridgeLogger(BridgeLoggerFactory owner, string category, ILogger fatal) : ILogger
+        {
+            private ILogger? _forward;
+            private ILogger Forward
+            {
+                get
+                {
+                    if (Volatile.Read(ref _forward) is { } cached) return cached;
+                    var host = Volatile.Read(ref owner._host);
+                    if (host is null) return NullLogger.Instance;
+                    var logger = host.CreateLogger(category);
+                    return Interlocked.CompareExchange(ref _forward, logger, null) ?? logger;
+                }
+            }
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => Forward.BeginScope(state);
+            public bool IsEnabled(LogLevel level) => fatal.IsEnabled(level) || Forward.IsEnabled(level);
+            public void Log<TState>(LogLevel level, EventId id, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                // This path is outside Serilog's provider filtering and sink error handling.
+                fatal.Log(level, id, state, exception, formatter);
+                Forward.Log(level, id, state, exception, formatter);
+            }
+        }
+    }
+
+    private sealed class NativeDispatcherLogger(CrashCoordinator coordinator) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel)
+            => logLevel >= LogLevel.Error;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel < LogLevel.Error || exception is null)
+            {
+                return;
+            }
+
+            string message;
+            try
+            {
+                message = formatter(state, exception);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (string.Equals(message, "NativeDispatcher unhandled exception", StringComparison.Ordinal))
+            {
+                coordinator.CaptureAndTerminate(exception, "Uno.NativeDispatcher");
+            }
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Emerald/Services/NativeDispatcherFatalLoggerProvider.cs
+++ b/Emerald/Services/NativeDispatcherFatalLoggerProvider.cs
@@ -4,9 +4,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Emerald.Services;
 
 /// <summary>
-/// Uno 6.6.184 catches exceptions raised by queued callbacks and reports them only
-/// through its logger. This narrow adapter turns that one known message back into
-/// Emerald's fatal policy while leaving all other framework logs unchanged.
+/// Fallback for Uno 6.6.184, whose Desktop dispatcher catches queued callback
+/// exceptions and reports them only through this exact logger category/message.
+/// Uno's generated Application.UnhandledException handler remains enabled and is
+/// Emerald's standard UI-exception path. This bridge must never turn arbitrary
+/// framework errors into crashes.
+///
+/// Upgrade contract: when changing Uno, rerun dispatcher, async-void, and UI
+/// unhandled-exception tests and confirm this log entry still includes an exception.
 /// </summary>
 internal sealed class NativeDispatcherFatalLoggerProvider(CrashCoordinator coordinator) : ILoggerProvider
 {

--- a/Emerald/Services/PlatformDiagnosticsProvider.cs
+++ b/Emerald/Services/PlatformDiagnosticsProvider.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using Emerald.CoreX.CrashHandling;
+
+namespace Emerald.Services;
+
+public sealed class PlatformDiagnosticsProvider : IPlatformDiagnosticsProvider
+{
+    public PlatformDiagnosticsResult FindRecent(DateTimeOffset occurredUtc)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return FindRecentWindowsDump(occurredUtc);
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return FindRecentMacReport(occurredUtc);
+            }
+
+            if (OperatingSystem.IsLinux())
+            {
+                return FindRecentLinuxCore(occurredUtc);
+            }
+        }
+        catch
+        {
+        }
+
+        return PlatformDiagnosticsResult.Unavailable("Platform diagnostics unavailable.");
+    }
+
+    private static PlatformDiagnosticsResult FindRecentWindowsDump(DateTimeOffset occurredUtc)
+    {
+        var localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localApplicationData))
+        {
+            return PlatformDiagnosticsResult.Unavailable("Windows local dump directory is unavailable.");
+        }
+
+        var crashDumpsPath = Path.Combine(localApplicationData, "CrashDumps");
+        var processName = Process.GetCurrentProcess().ProcessName;
+        return FindRecentFile(
+            crashDumpsPath,
+            occurredUtc,
+            file => file.Extension.Equals(".dmp", StringComparison.OrdinalIgnoreCase)
+                    && (file.Name.StartsWith(processName, StringComparison.OrdinalIgnoreCase)
+                        || file.Name.StartsWith($"{processName}.", StringComparison.OrdinalIgnoreCase)),
+            "No matching Windows Error Reporting dump was found.");
+    }
+
+    private static PlatformDiagnosticsResult FindRecentMacReport(DateTimeOffset occurredUtc)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+        {
+            return PlatformDiagnosticsResult.Unavailable("macOS DiagnosticReports directory is unavailable.");
+        }
+
+        var reportsPath = Path.Combine(home, "Library", "Logs", "DiagnosticReports");
+        var processName = Process.GetCurrentProcess().ProcessName;
+        return FindRecentFile(
+            reportsPath,
+            occurredUtc,
+            file => (file.Extension.Equals(".crash", StringComparison.OrdinalIgnoreCase)
+                     || file.Extension.Equals(".ips", StringComparison.OrdinalIgnoreCase))
+                    && file.Name.Contains(processName, StringComparison.OrdinalIgnoreCase),
+            "No matching macOS DiagnosticReports entry was found.");
+    }
+
+    private static PlatformDiagnosticsResult FindRecentLinuxCore(DateTimeOffset occurredUtc)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var candidates = new List<string>
+        {
+            "/var/lib/systemd/coredump"
+        };
+
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            candidates.Add(Path.Combine(home, ".local", "share", "systemd", "coredump"));
+            candidates.Add(Path.Combine(home, ".cache", "systemd", "coredump"));
+        }
+
+        foreach (var candidate in candidates)
+        {
+            var result = FindRecentFile(
+                candidate,
+                occurredUtc,
+                file => file.Name.Contains("emerald", StringComparison.OrdinalIgnoreCase)
+                        || file.Name.Contains(Process.GetCurrentProcess().ProcessName, StringComparison.OrdinalIgnoreCase),
+                "No matching systemd-coredump entry was found.");
+            if (result.IsAvailable)
+            {
+                return result;
+            }
+        }
+
+        return PlatformDiagnosticsResult.Unavailable("systemd-coredump is unavailable or did not expose a matching core.");
+    }
+
+    private static PlatformDiagnosticsResult FindRecentFile(
+        string directory,
+        DateTimeOffset occurredUtc,
+        Func<FileInfo, bool> predicate,
+        string unavailableMessage)
+    {
+        if (!Directory.Exists(directory))
+        {
+            return PlatformDiagnosticsResult.Unavailable(unavailableMessage);
+        }
+
+        var lowerBound = occurredUtc.UtcDateTime.AddMinutes(-10);
+        var upperBound = occurredUtc.UtcDateTime.AddMinutes(5);
+        var file = new DirectoryInfo(directory)
+            .EnumerateFiles("*", SearchOption.TopDirectoryOnly)
+            .Where(predicate)
+            .Where(candidate => candidate.LastWriteTimeUtc >= lowerBound)
+            .Where(candidate => candidate.LastWriteTimeUtc <= upperBound)
+            .OrderByDescending(candidate => candidate.LastWriteTimeUtc)
+            .FirstOrDefault();
+
+        return file is null
+            ? PlatformDiagnosticsResult.Unavailable(unavailableMessage)
+            : new PlatformDiagnosticsResult("Available", file.FullName);
+    }
+}

--- a/Emerald/Services/PlatformFolderLauncher.cs
+++ b/Emerald/Services/PlatformFolderLauncher.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace Emerald.Services;
+
+public static class PlatformFolderLauncher
+{
+    public static bool TryOpen(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            var startInfo = OperatingSystem.IsWindows()
+                ? CreateWindowsStartInfo(path)
+                : OperatingSystem.IsMacOS()
+                    ? CreateUnixStartInfo("open", path)
+                    : CreateUnixStartInfo("xdg-open", path);
+
+            return Process.Start(startInfo) is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static ProcessStartInfo CreateWindowsStartInfo(string path)
+    {
+        var startInfo = new ProcessStartInfo("explorer.exe")
+        {
+            UseShellExecute = true
+        };
+        startInfo.ArgumentList.Add(path);
+        return startInfo;
+    }
+
+    private static ProcessStartInfo CreateUnixStartInfo(string command, string path)
+    {
+        var startInfo = new ProcessStartInfo(command)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(path);
+        return startInfo;
+    }
+}

--- a/Emerald/Services/SettingsService.cs
+++ b/Emerald/Services/SettingsService.cs
@@ -65,23 +65,38 @@ public class SettingsService(
 
     public void SaveData()
     {
-        try
+        lock (_saveGate)
         {
-            _suppressTracking = true;
-            Settings.LastSaved = DateTime.Now;
-            baseService.Set(SettingsKeys.Settings, Settings);
-            globalGameSettingsService.Save();
-            logger.LogInformation("Settings saved successfully.");
+            try
+            {
+                _suppressTracking = true;
+                Settings.LastSaved = DateTime.Now;
+                baseService.Set(SettingsKeys.Settings, Settings);
+                globalGameSettingsService.Save();
+                logger.LogInformation("Settings saved successfully.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error saving settings data.");
+                throw;
+            }
+            finally
+            {
+                _suppressTracking = false;
+            }
         }
-        catch (Exception ex)
+    }
+
+    public void FlushPendingSave()
+    {
+        lock (_saveGate)
         {
-            logger.LogError(ex, "Error saving settings data.");
-            throw;
+            _pendingSaveCts?.Cancel();
+            _pendingSaveCts?.Dispose();
+            _pendingSaveCts = null;
         }
-        finally
-        {
-            _suppressTracking = false;
-        }
+
+        SaveData();
     }
 
     private void AttachTracking()

--- a/Emerald/Strings/en/Resources.resw
+++ b/Emerald/Strings/en/Resources.resw
@@ -1292,4 +1292,32 @@
   <data name="GameOptionsCategorySound" xml:space="preserve"><value>Sound</value></data>
   <data name="GameOptionsCategoryKeyBindings" xml:space="preserve"><value>Key Bindings</value></data>
   <data name="GameOptionsCategoryUnsupported" xml:space="preserve"><value>Unsupported</value></data>
+  <data name="CrashReports" xml:space="preserve"><value>Crash reports</value></data>
+  <data name="CrashReportsDescription" xml:space="preserve"><value>Emerald can be buggy sometimes because there's only very few developers (mainly one), So you can review Emerald launcher crashes here and report it in Github only if you want.</value></data>
+  <data name="CrashReportsCount" xml:space="preserve"><value>saved report(s)</value></data>
+  <data name="CrashReportsNewCount" xml:space="preserve"><value>new report(s)</value></data>
+  <data name="ViewCrashReports" xml:space="preserve"><value>View crash reports</value></data>
+  <data name="ViewCrashReport" xml:space="preserve"><value>View crash report</value></data>
+  <data name="Dismiss" xml:space="preserve"><value>Dismiss</value></data>
+  <data name="Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="ManagedCrash" xml:space="preserve"><value>Emerald crash</value></data>
+  <data name="UnexpectedShutdown" xml:space="preserve"><value>Unexpected shutdown</value></data>
+  <data name="CrashDetailsUnavailable" xml:space="preserve"><value>Crash details unavailable</value></data>
+  <data name="New" xml:space="preserve"><value>New</value></data>
+  <data name="CopyCrashReport" xml:space="preserve"><value>Copy report</value></data>
+  <data name="ReportToGitHub" xml:space="preserve"><value>Report on GitHub</value></data>
+  <data name="OpenCrashLogs" xml:space="preserve"><value>Open Emerald logs</value></data>
+  <data name="OpenNativeDiagnostics" xml:space="preserve"><value>Open native diagnostics</value></data>
+  <data name="DeleteAllCrashReports" xml:space="preserve"><value>Delete all reports</value></data>
+  <data name="DeleteAllCrashReportsDescription" xml:space="preserve"><value>Delete every saved crash report? This cannot be undone.</value></data>
+  <data name="DeleteCrashReport" xml:space="preserve"><value>Delete crash report</value></data>
+  <data name="DeleteCrashReportDescription" xml:space="preserve"><value>Delete this crash report? This cannot be undone.</value></data>
+  <data name="EmeraldCrashDetected" xml:space="preserve"><value>Emerald closed unexpectedly</value></data>
+  <data name="CrashRecoveryDescription" xml:space="preserve"><value>Emerald encountered a problem and saved diagnostic details. You can review the report or share it with the Emerald project.</value></data>
+  <data name="UnexpectedShutdownDescription" xml:space="preserve"><value>Emerald did not close normally. This report contains the last available diagnostics.</value></data>
+  <data name="HideCrashDetails" xml:space="preserve"><value>Hide details</value></data>
+  <data name="TryNormalStartup" xml:space="preserve"><value>Try normal startup</value></data>
+  <data name="CouldNotOpenGitHubReport" xml:space="preserve"><value>Could not open the GitHub report page.</value></data>
+  <data name="RecoveryMode" xml:space="preserve"><value>Emerald recovery mode</value></data>
+  <data name="RecoveryModeDescription" xml:space="preserve"><value>Emerald has failed during startup several times. Nonessential startup work was skipped so you can inspect crash reports before continuing.</value></data>
 </root>

--- a/Emerald/ViewModels/CrashReportsPageViewModel.cs
+++ b/Emerald/ViewModels/CrashReportsPageViewModel.cs
@@ -1,0 +1,118 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Emerald.CoreX.CrashHandling;
+using Emerald.CoreX.Helpers;
+using Emerald.Helpers;
+using Emerald.Services;
+
+namespace Emerald.ViewModels;
+
+public sealed class CrashReportsPageViewModel : ObservableObject
+{
+    private readonly CrashCoordinator _crashCoordinator;
+    private CrashReportListItem? _selectedReport;
+
+    public CrashReportsPageViewModel(CrashCoordinator crashCoordinator)
+        => _crashCoordinator = crashCoordinator;
+
+    public ObservableCollection<CrashReportListItem> Reports { get; } = [];
+
+    public CrashReportListItem? SelectedReport
+    {
+        get => _selectedReport;
+        set
+        {
+            if (SetProperty(ref _selectedReport, value))
+            {
+                OnPropertyChanged(nameof(SelectedRecord));
+                OnPropertyChanged(nameof(SelectedReportText));
+                OnPropertyChanged(nameof(SelectedReportPath));
+                OnPropertyChanged(nameof(SelectedNativeDiagnosticsPath));
+                OnPropertyChanged(nameof(HasSelectedNativeDiagnostics));
+                OnPropertyChanged(nameof(HasSelectedReport));
+            }
+        }
+    }
+
+    public CrashRecord? SelectedRecord => SelectedReport?.Record;
+    public bool HasReports => Reports.Count > 0;
+    public bool HasSelectedReport => SelectedRecord is not null;
+    public bool HasSelectedNativeDiagnostics => !string.IsNullOrWhiteSpace(SelectedNativeDiagnosticsPath);
+    public string SelectedReportText => SelectedRecord is null ? string.Empty : CrashReportFormatter.ToText(SelectedRecord);
+    public string? SelectedReportPath => SelectedRecord?.ReportPath;
+    public string? SelectedNativeDiagnosticsPath => SelectedRecord?.NativeDiagnosticsPath;
+    public string ReportsPath => _crashCoordinator.ReportsPath;
+    public string ApplicationLogPath => _crashCoordinator.ApplicationLogPath;
+
+    public void Refresh(string? reportId = null)
+    {
+        var records = _crashCoordinator.GetReports();
+        Reports.Clear();
+        foreach (var record in records)
+        {
+            Reports.Add(new CrashReportListItem(record));
+        }
+
+        SelectedReport = reportId is null
+            ? Reports.FirstOrDefault()
+            : Reports.FirstOrDefault(item => string.Equals(item.Record.Id, reportId, StringComparison.Ordinal))
+              ?? Reports.FirstOrDefault();
+        OnPropertyChanged(nameof(HasReports));
+    }
+
+    public GitHubIssueDraft? GetSelectedGitHubDraft()
+        => SelectedRecord is null
+            ? null
+            : new GitHubCrashIssueComposer("https://github.com/RiversideValley/Emerald").Compose(SelectedRecord);
+
+    public void EnrichNativeDiagnostics()
+        => _crashCoordinator.EnrichNativeDiagnostics();
+
+    public bool AcknowledgeSelected()
+        => SelectedRecord is not null && _crashCoordinator.Acknowledge(SelectedRecord.Id);
+
+    public bool DeleteSelected()
+    {
+        var record = SelectedRecord;
+        if (record is null || !_crashCoordinator.Delete(record.Id))
+        {
+            return false;
+        }
+
+        Refresh();
+        return true;
+    }
+
+    public int DeleteAll()
+    {
+        var deleted = _crashCoordinator.DeleteAll();
+        Refresh();
+        return deleted;
+    }
+}
+
+public sealed class CrashReportListItem
+{
+    public CrashReportListItem(CrashRecord record)
+        => Record = record;
+
+    public CrashRecord Record { get; }
+
+    public string Title
+        => Record.Kind == CrashRecordKind.ManagedCrash
+            ? "ManagedCrash".Localize()
+            : "UnexpectedShutdown".Localize();
+
+    public string OccurredText
+        => Record.OccurredUtc.ToLocalTime().ToString("g");
+
+    public string Summary
+        => Record.Exception?.Type
+           ?? Record.NativeDiagnosticsStatus
+           ?? "CrashDetailsUnavailable".Localize();
+
+    public string Status
+        => Record.IsAcknowledged
+            ? string.Empty
+            : "New".Localize();
+}

--- a/Emerald/Views/GamesPage.xaml
+++ b/Emerald/Views/GamesPage.xaml
@@ -256,6 +256,7 @@
                             Style="{ThemeResource AccentButtonStyle}" />
           </StackPanel>
           <ItemsRepeater
+                        x:Name="GamesItemsRepeater"
                         ItemTemplate="{StaticResource GameItemTemplate}"
                         ItemsSource="{x:Bind ViewModel.FilteredGames, Mode=OneWay}"
                         Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource InverseBoolToVis}}">

--- a/Emerald/Views/GamesPage.xaml.cs
+++ b/Emerald/Views/GamesPage.xaml.cs
@@ -37,7 +37,22 @@ public sealed partial class GamesPage : Page
     protected override async void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
+        // The view model is singleton-scoped while this page is recreated by the
+        // shell. Reattach the view-owned repeater after a previous page instance
+        // detached it during navigation.
+        GamesItemsRepeater.ItemsSource = ViewModel.FilteredGames;
         await ViewModel.InitializeCommand.ExecuteAsync(null);
+    }
+
+    protected override void OnNavigatedFrom(NavigationEventArgs e)
+    {
+        // WinUI keeps a native CollectionChanged delegate for ItemsRepeater's
+        // ItemsSource. Leaving it attached after this page is removed lets the
+        // singleton view model call a dead COM delegate on its next projection
+        // update (0x80004005). Release the view-owned subscription before the
+        // frame tears down this page instance.
+        GamesItemsRepeater.ItemsSource = null;
+        base.OnNavigatedFrom(e);
     }
 
     private async void AddGame_Click(object sender, RoutedEventArgs e)

--- a/Emerald/Views/Settings/AboutPage.xaml
+++ b/Emerald/Views/Settings/AboutPage.xaml
@@ -100,6 +100,23 @@
                 </cn:SettingsCard.Content>
             </cn:SettingsCard>
 
+            <cn:SettingsCard
+                Header="{helpers:Localize KeyName=CrashReports}"
+                Description="{helpers:Localize KeyName=CrashReportsDescription}"
+                HeaderIcon="{helpers:FontIcon Glyph=&#xE7BA;}">
+                <cn:SettingsCard.Content>
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+                            Text="{x:Bind CrashReportCountText, Mode=OneWay}" />
+                        <Button
+                            Click="OpenCrashReports_Click"
+                            Content="{helpers:Localize KeyName=ViewCrashReports}" />
+                    </StackPanel>
+                </cn:SettingsCard.Content>
+            </cn:SettingsCard>
+
             <cn:SettingsExpander
                 Header="{helpers:Localize KeyName=Updates}"
                 Description="{helpers:Localize KeyName=UpdatesDescription}"

--- a/Emerald/Views/Settings/AboutPage.xaml.cs
+++ b/Emerald/Views/Settings/AboutPage.xaml.cs
@@ -173,6 +173,7 @@ public sealed partial class AboutPage : Page
 
     private readonly IAppUpdateService _updateService;
     private readonly INotificationService _notifications;
+    private readonly CrashCoordinator _crashCoordinator;
     private readonly List<ChannelOption> _availableChannels;
 
     private bool _isCheckingForUpdates;
@@ -183,6 +184,11 @@ public sealed partial class AboutPage : Page
     public string PackageVersion => DirectResoucres.PackageVersion;
     public string BuildTypeLabel => $"{DirectResoucres.BuildType} | {GetChannelLabel(DirectResoucres.ReleaseChannel)}";
     public string BuildInfo => $"{GetChannelLabel(DirectResoucres.ReleaseChannel)} {DirectResoucres.Architecture}";
+    public string CrashReportCountText
+        => string.Concat(
+            _crashCoordinator.GetUnacknowledgedReports().Count,
+            " ",
+            "CrashReportsNewCount".Localize());
 
     public IReadOnlyList<ChannelOption> AvailableChannels => _availableChannels;
     public Visibility NightlyArtifactsCardVisibility =>
@@ -217,6 +223,7 @@ public sealed partial class AboutPage : Page
         SS = Ioc.Default.GetRequiredService<Services.SettingsService>();
         _updateService = Ioc.Default.GetRequiredService<IAppUpdateService>();
         _notifications = Ioc.Default.GetRequiredService<INotificationService>();
+        _crashCoordinator = Ioc.Default.GetRequiredService<CrashCoordinator>();
 
         _availableChannels =
         [
@@ -227,6 +234,7 @@ public sealed partial class AboutPage : Page
 
         InitializeComponent();
         Bindings.Update();
+        Loaded += (_, _) => Bindings.Update();
     }
 
     private async Task CheckForUpdatesAsync()
@@ -451,6 +459,9 @@ public sealed partial class AboutPage : Page
 
     private async void CheckUpdates_Click(object sender, RoutedEventArgs e)
         => await CheckForUpdatesAsync();
+
+    private void OpenCrashReports_Click(object sender, RoutedEventArgs e)
+        => Frame?.Navigate(typeof(CrashReportsPage));
 
     private async void OpenNightlyArtifacts_Click(object sender, RoutedEventArgs e)
     {

--- a/Emerald/Views/Settings/CrashReportsPage.xaml
+++ b/Emerald/Views/Settings/CrashReportsPage.xaml
@@ -90,6 +90,7 @@
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         BorderThickness="1"
         CornerRadius="8">
+      <ScrollViewer>
       <Grid RowSpacing="8">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto" />
@@ -128,6 +129,7 @@
               IsEnabled="{x:Bind ViewModel.HasSelectedNativeDiagnostics, Mode=OneWay}" />
         </StackPanel>
       </Grid>
+      </ScrollViewer>
     </Border>
   </Grid>
 </Page>

--- a/Emerald/Views/Settings/CrashReportsPage.xaml
+++ b/Emerald/Views/Settings/CrashReportsPage.xaml
@@ -1,0 +1,133 @@
+<Page
+    x:Class="Emerald.Views.Settings.CrashReportsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Emerald.Helpers"
+    xmlns:local="using:Emerald.ViewModels"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+  <Grid Margin="16" RowSpacing="12">
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="320" />
+      <ColumnDefinition Width="*" />
+    </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.ColumnSpan="2" Spacing="4">
+      <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{helpers:Localize KeyName=CrashReports}" />
+      <TextBlock
+          Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+          Text="{helpers:Localize KeyName=CrashReportsDescription}"
+          TextWrapping="WrapWholeWords" />
+    </StackPanel>
+
+    <Border
+        Grid.Row="1"
+        Margin="0,0,12,0"
+        Padding="8"
+        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        BorderThickness="1"
+        CornerRadius="8">
+      <Grid RowSpacing="8">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ListView
+            x:Name="ReportsListView"
+            ItemsSource="{x:Bind ViewModel.Reports, Mode=OneWay}"
+            SelectedItem="{x:Bind ViewModel.SelectedReport, Mode=TwoWay}"
+            SelectionMode="Single">
+          <ListView.ItemTemplate>
+            <DataTemplate x:DataType="local:CrashReportListItem">
+              <Grid Padding="8" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Spacing="2">
+                  <TextBlock FontWeight="SemiBold" Text="{x:Bind Title}" />
+                  <TextBlock
+                      FontSize="12"
+                      Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+                      Text="{x:Bind Summary}"
+                      TextTrimming="CharacterEllipsis" />
+                  <TextBlock
+                      FontSize="11"
+                      Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}"
+                      Text="{x:Bind OccurredText}" />
+                </StackPanel>
+                <TextBlock
+                    Grid.Column="1"
+                    FontSize="12"
+                    Foreground="{ThemeResource SystemControlHighlightAltAccentBrush}"
+                    Text="{x:Bind Status}"
+                    VerticalAlignment="Top" />
+              </Grid>
+            </DataTemplate>
+          </ListView.ItemTemplate>
+        </ListView>
+        <Button
+            Grid.Row="1"
+            Click="DeleteAll_Click"
+            Content="{helpers:Localize KeyName=DeleteAllCrashReports}"
+            HorizontalAlignment="Stretch"
+            IsEnabled="{x:Bind ViewModel.HasReports, Mode=OneWay}" />
+      </Grid>
+    </Border>
+
+    <Border
+        Grid.Row="1"
+        Grid.Column="1"
+        Padding="12"
+        Background="{ThemeResource LayerFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        BorderThickness="1"
+        CornerRadius="8">
+      <Grid RowSpacing="8">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="*" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Spacing="8">
+          <Button
+              Click="CopyReport_Click"
+              Content="{helpers:Localize KeyName=CopyCrashReport}"
+              IsEnabled="{x:Bind ViewModel.HasSelectedReport, Mode=OneWay}" />
+          <Button
+              Click="ReportOnGitHub_Click"
+              Content="{helpers:Localize KeyName=ReportToGitHub}"
+              IsEnabled="{x:Bind ViewModel.HasSelectedReport, Mode=OneWay}" />
+          <Button
+              Click="Delete_Click"
+              Content="{helpers:Localize KeyName=Delete}"
+              IsEnabled="{x:Bind ViewModel.HasSelectedReport, Mode=OneWay}" />
+        </StackPanel>
+        <TextBox
+            Grid.Row="1"
+            AcceptsReturn="True"
+            IsReadOnly="True"
+            IsSpellCheckEnabled="False"
+            Text="{x:Bind ViewModel.SelectedReportText, Mode=OneWay}"
+            TextWrapping="NoWrap" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8">
+          <Button
+              Click="OpenLogs_Click"
+              Content="{helpers:Localize KeyName=OpenCrashLogs}"
+              IsEnabled="{x:Bind ViewModel.HasSelectedReport, Mode=OneWay}" />
+          <Button
+              Click="OpenNativeDiagnostics_Click"
+              Content="{helpers:Localize KeyName=OpenNativeDiagnostics}"
+              IsEnabled="{x:Bind ViewModel.HasSelectedNativeDiagnostics, Mode=OneWay}" />
+        </StackPanel>
+      </Grid>
+    </Border>
+  </Grid>
+</Page>

--- a/Emerald/Views/Settings/CrashReportsPage.xaml.cs
+++ b/Emerald/Views/Settings/CrashReportsPage.xaml.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Emerald.CoreX.Helpers;
+using Emerald.Helpers;
+using Emerald.Services;
+using Emerald.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.System;
+using LocalMessageBoxButtons = Emerald.Helpers.Enums.MessageBoxButtons;
+using LocalMessageBoxResults = Emerald.Helpers.Enums.MessageBoxResults;
+
+namespace Emerald.Views.Settings;
+
+public sealed partial class CrashReportsPage : Page
+{
+    public CrashReportsPageViewModel ViewModel { get; }
+
+    public CrashReportsPage()
+    {
+        ViewModel = Ioc.Default.GetRequiredService<CrashReportsPageViewModel>();
+        DataContext = ViewModel;
+        InitializeComponent();
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        var reportId = e.Parameter as string;
+        ViewModel.Refresh(reportId);
+        _ = RefreshAfterNativeDiagnosticsAsync(reportId);
+    }
+
+    private async Task RefreshAfterNativeDiagnosticsAsync(string? reportId)
+    {
+        try
+        {
+            await Task.Run(ViewModel.EnrichNativeDiagnostics);
+            DispatcherQueue.TryEnqueue(() => ViewModel.Refresh(reportId));
+        }
+        catch (Exception exception)
+        {
+            this.Log().LogDebug(exception, "Native crash evidence refresh was unavailable.");
+        }
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ViewModel.SelectedReport))
+        {
+            ReportsListView.SelectedItem = ViewModel.SelectedReport;
+        }
+    }
+
+    private void CopyReport_Click(object sender, RoutedEventArgs e)
+    {
+        var text = ViewModel.SelectedReportText;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        try
+        {
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+            package.SetText(text);
+            Clipboard.SetContent(package);
+        }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not copy the crash report to the clipboard.");
+        }
+    }
+
+    private async void ReportOnGitHub_Click(object sender, RoutedEventArgs e)
+    {
+        var draft = ViewModel.GetSelectedGitHubDraft();
+        if (draft is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+            package.SetText(draft.FullReport);
+            Clipboard.SetContent(package);
+            ViewModel.AcknowledgeSelected();
+
+            if (!Uri.TryCreate(draft.Url, UriKind.Absolute, out var uri)
+                || !await Launcher.LaunchUriAsync(uri))
+            {
+                await MessageBox.Show("Error".Localize(), "CouldNotOpenGitHubReport".Localize(), LocalMessageBoxButtons.Ok);
+            }
+        }
+        catch (Exception exception)
+        {
+            this.Log().LogWarning(exception, "Could not prepare a GitHub crash report.");
+        }
+    }
+
+    private async void Delete_Click(object sender, RoutedEventArgs e)
+    {
+        if (!ViewModel.HasSelectedReport)
+        {
+            return;
+        }
+
+        var result = await MessageBox.Show(
+            "DeleteCrashReport".Localize(),
+            "DeleteCrashReportDescription".Localize(),
+            LocalMessageBoxButtons.YesNo);
+        if (result == LocalMessageBoxResults.Yes)
+        {
+            ViewModel.DeleteSelected();
+        }
+    }
+
+    private async void DeleteAll_Click(object sender, RoutedEventArgs e)
+    {
+        var result = await MessageBox.Show(
+            "DeleteAllCrashReports".Localize(),
+            "DeleteAllCrashReportsDescription".Localize(),
+            LocalMessageBoxButtons.YesNo);
+        if (result == LocalMessageBoxResults.Yes)
+        {
+            ViewModel.DeleteAll();
+        }
+    }
+
+    private void OpenLogs_Click(object sender, RoutedEventArgs e)
+        => PlatformFolderLauncher.TryOpen(Path.GetDirectoryName(ViewModel.ApplicationLogPath));
+
+    private void OpenNativeDiagnostics_Click(object sender, RoutedEventArgs e)
+        => PlatformFolderLauncher.TryOpen(Path.GetDirectoryName(ViewModel.SelectedNativeDiagnosticsPath));
+}

--- a/Emerald/Views/Settings/SettingsPage.xaml
+++ b/Emerald/Views/Settings/SettingsPage.xaml
@@ -72,7 +72,7 @@
             Background="{ThemeResource LayerFillColorDefaultBrush}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,0">
-      <ScrollViewer>
+      <ScrollViewer x:Name="contentScrollViewer">
         <Frame Padding="16" x:Name="contentframe" />
       </ScrollViewer>
     </Grid>

--- a/Emerald/Views/Settings/SettingsPage.xaml.cs
+++ b/Emerald/Views/Settings/SettingsPage.xaml.cs
@@ -1,17 +1,40 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Navigation;
 using System;
 
 namespace Emerald.Views.Settings;
 
 public sealed partial class SettingsPage : Page
 {
+    private CrashReportsNavigationRequest? _pendingCrashReportsNavigation;
+
     public SettingsPage()
     {
         InitializeComponent();
 
-        Loaded += (_, _) => 
-                NavigateOnce(typeof(GeneralPage));
+        Loaded += SettingsPage_Loaded;
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        _pendingCrashReportsNavigation = e.Parameter as CrashReportsNavigationRequest;
+    }
+
+    private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (_pendingCrashReportsNavigation is not null)
+        {
+            var aboutItem = navView.MenuItems
+                .OfType<NavigationViewItem>()
+                .FirstOrDefault(item => string.Equals(item.Tag as string, "About", StringComparison.OrdinalIgnoreCase));
+            navView.SelectedItem = aboutItem;
+            NavigateOnce(typeof(CrashReportsPage), _pendingCrashReportsNavigation.ReportId);
+            return;
+        }
+
+        NavigateOnce(typeof(GeneralPage));
     }
 
     private void navView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
@@ -35,11 +58,13 @@ public sealed partial class SettingsPage : Page
         }
     }
 
-    private void NavigateOnce(Type type)
+    private void NavigateOnce(Type type, object? parameter = null)
     {
         if (contentframe.Content == null || contentframe.Content.GetType() != type)
         {
-            contentframe.Navigate(type, null, new DrillInNavigationTransitionInfo());
+            contentframe.Navigate(type, parameter, new DrillInNavigationTransitionInfo());
         }
     }
 }
+
+public sealed record CrashReportsNavigationRequest(string? ReportId);

--- a/Emerald/Views/Settings/SettingsPage.xaml.cs
+++ b/Emerald/Views/Settings/SettingsPage.xaml.cs
@@ -60,10 +60,22 @@ public sealed partial class SettingsPage : Page
 
     private void NavigateOnce(Type type, object? parameter = null)
     {
+        ConfigureContentScrolling(type == typeof(CrashReportsPage));
+
         if (contentframe.Content == null || contentframe.Content.GetType() != type)
         {
             contentframe.Navigate(type, parameter, new DrillInNavigationTransitionInfo());
         }
+    }
+
+    private void ConfigureContentScrolling(bool usePageLevelScrolling)
+    {
+        contentScrollViewer.VerticalScrollMode = usePageLevelScrolling
+            ? ScrollMode.Disabled
+            : ScrollMode.Enabled;
+        contentScrollViewer.VerticalScrollBarVisibility = usePageLevelScrolling
+            ? ScrollBarVisibility.Disabled
+            : ScrollBarVisibility.Auto;
     }
 }
 

--- a/docs/crash-testing.md
+++ b/docs/crash-testing.md
@@ -1,0 +1,41 @@
+# Testing launcher crashes
+
+Build Debug, then select a launch profile in `Emerald/Properties/launchSettings.json`:
+
+- **Crash - MainPage**: throws during essential shell initialization.
+- **Crash - Dispatcher**: throws in an actual queued Uno dispatcher callback.
+- **Crash - DesktopHost**: throws before desktop host construction.
+- **Emerald (Desktop)**: normal startup, with `EMERALD_TEST=0`. Launch this after a crash profile to see recovery and history.
+- **Crash - MainPage (WinAppSDK Packaged)**: packaged Windows equivalent of the MainPage test.
+- **Crash - Dispatcher (WinAppSDK Packaged)**: packaged Windows equivalent of the dispatcher test.
+- **Crash - Startup (WinAppSDK Packaged)**: throws at WinAppSDK launch, the packaged equivalent of the pre-host startup test.
+- **Emerald (WinAppSDK Packaged)**: normal packaged Windows startup. Launch this after a packaged crash profile to see recovery and history.
+
+Crash profiles deliberately throw once **per process**, every launch. Historical `.once` files are ignored; no cleanup or environment-variable removal is needed to repeat a test. An armed crash profile bypasses previous recovery prompts so it can reach its requested fault. Normal Desktop startup does not inject another fault and shows the saved crash automatically.
+
+All test environment variables are effective only in Debug with `EMERALD_TEST=1`. The checked-in manual crash profiles leave `EMERALD_TEST_DATA_ROOT` empty, so they use exactly the same settings, lifecycle files, and report history as normal Desktop. These profiles intentionally crash your regular development instance; save ongoing work before using them.
+
+Packaged WinAppSDK profiles use gated command-line activation arguments instead of `environmentVariables`, because Visual Studio's MSIX launcher does not reliably propagate profile environment variables. `--emerald-test=1` is still required before any packaged test option is honored, and the normal packaged profile explicitly passes `--emerald-test=0`. Packaged tests use the package's regular local app-data directory, so recovery appears when the ordinary packaged profile is launched next.
+
+For automated tests, set `EMERALD_TEST_DATA_ROOT` to a writable absolute temporary directory. That isolates settings, reports, lifecycle files, and fallback diagnostics. To inspect that isolated run, retain the same root with `EMERALD_TEST=1` and an empty `EMERALD_TEST_CRASH`. Reports from the previous `/tmp/emerald-crash-test` profiles remain in that folder; they are not deleted or automatically imported into normal history.
+
+Recovery uses one dialog: View shows details in place, Report and Open logs leave it open, and Continue starts the shell. After repeated startup failures, the same dialog explains recovery mode and uses an explicit Try normal startup button. There is no separate recovery launch profile or follow-up crash notification dialog.
+
+Additional `EMERALD_TEST_CRASH` values for automated validation are `MainPage_Loaded_BeforeAwait`, `MainPage_Loaded_AfterAwait`, `AsyncVoidBeforeAwait`, `AsyncVoidAfterAwait`, `WorkerThread`, and `CaptureThenTerminate`. `OrdinaryError` and `UnobservedTask` exercise nonfatal paths. `EMERALD_TEST_DISABLE_STUDIO=1` disables Studio only while test mode is enabled.
+
+## Real application process tests
+
+Build the solution, then point the opt-in test suite at the Debug desktop executable (not the DLL):
+
+```sh
+dotnet build Emerald.slnx
+EMERALD_PROCESS_TEST_APP="$PWD/Emerald/bin/Debug/net10.0-desktop/Emerald" \
+  dotnet test Emerald.CoreX.Tests/Emerald.CoreX.Tests.csproj --no-build \
+  --filter FullyQualifiedName~CrashProfileProcessTests
+```
+
+On Windows use the corresponding `.exe`. These tests need an interactive desktop session. They launch the actual app, repeat each fatal case using the same isolated directory, assert termination and exactly one report per run, then relaunch and wait for the actual recovery dialog's `Opened` event before host construction. Separate checks require normal startup and nonfatal errors to reach `ShellReady`. Test-owned processes are terminated and their temporary directories removed afterward. Native OS crash reports may still be retained by the OS.
+
+An isolated Debug-only action seam (`EMERALD_TEST_RECOVERY_ACTION=view-continue`) exercises the same View and Continue callbacks as the dialog buttons. Process tests use it after one and three failed launches to verify acknowledgement, a single recovery dialog, and successful shell initialization. It is ignored without both test mode and an isolated data root.
+
+Without `EMERALD_PROCESS_TEST_APP`, process tests are explicitly skipped; the ordinary CoreX suite still runs. An alive process alone is never treated as proof that startup or recovery succeeded. Dialog appearance and button interactions still need visual validation on Windows, macOS, and Linux.

--- a/docs/crash-testing.md
+++ b/docs/crash-testing.md
@@ -21,7 +21,13 @@ For automated tests, set `EMERALD_TEST_DATA_ROOT` to a writable absolute tempora
 
 Recovery uses one dialog: View shows details in place, Report and Open logs leave it open, and Continue starts the shell. After repeated startup failures, the same dialog explains recovery mode and uses an explicit Try normal startup button. There is no separate recovery launch profile or follow-up crash notification dialog.
 
-Additional `EMERALD_TEST_CRASH` values for automated validation are `MainPage_Loaded_BeforeAwait`, `MainPage_Loaded_AfterAwait`, `AsyncVoidBeforeAwait`, `AsyncVoidAfterAwait`, `WorkerThread`, and `CaptureThenTerminate`. `OrdinaryError` and `UnobservedTask` exercise nonfatal paths. `EMERALD_TEST_DISABLE_STUDIO=1` disables Studio only while test mode is enabled.
+Additional `EMERALD_TEST_CRASH` values for automated validation are `MainPage_Loaded_BeforeAwait`, `MainPage_Loaded_AfterAwait`, `AsyncVoidBeforeAwait`, `AsyncVoidAfterAwait`, `WorkerThread`, `CaptureThenTerminate`, and `UnoApplicationUnhandled`. The last value exercises Emerald's callback policy after Uno has surfaced a UI exception; it does not simulate Uno framework event delivery. `OrdinaryError` and `UnobservedTask` exercise nonfatal paths. `EMERALD_TEST_DISABLE_STUDIO=1` disables Studio only while test mode is enabled.
+
+## Uno unhandled-exception behavior
+
+Uno's generated `Application.UnhandledException` handler remains enabled; Emerald subscribes after XAML initialization so it captures and terminates only if execution continues. Debug Desktop builds set Uno's `BreakOnUnhandledExceptions` option, so an attached debugger breaks first. Release builds retain Uno's default non-breaking behavior.
+
+The `NativeDispatcherFatalLoggerProvider` is a narrow Uno 6.6.184 fallback for queued dispatcher and `async void` exceptions that Desktop logs instead of surfacing through `Application.UnhandledException`. It is not a general error-log-to-crash conversion. Whenever Uno changes, rerun the dispatcher, both `AsyncVoid` cases, and a real UI-unhandled exception on Windows MSIX, macOS, and Linux; confirm the exception is captured once, the correct source is recorded, and recovery appears on the next normal launch.
 
 ## Real application process tests
 


### PR DESCRIPTION
## Summary

This PR repairs Emerald launcher crash handling across the maintained Uno targets. Fatal failures are now captured durably, the process terminates deterministically, and the next launch provides a single recovery experience with report history and user-controlled GitHub reporting.

## What this fixes

- Previously, exceptions raised from async UI handlers and queued Uno dispatcher callbacks could be caught by the framework logger without reaching Emerald’s global handlers. The application could remain open after a fatal exception, fail to show a crash dialog, or lose the crash details. Normal shutdown and updater termination could also be mistaken for unexpected crashes, and recovery could present duplicate dialogs.
- Cause: the singleton `GamesPageViewModel` updates `FilteredGames` after an old `GamesPage` is removed. Its old WinUI `ItemsRepeater` collection callback can remain attached, so `Clear()` invokes a dead native delegate and throws `COMException 0x80004005`.

## Implementation

- Added reusable CoreX crash records, atomic JSON/text persistence, exception-chain serialization, redaction, bounded log context, lifecycle markers, stale-session reconciliation, and recovery-mode tracking.
- Added early, idempotent fatal handling with synchronous capture and deterministic process termination.
- Added a narrow Uno `NativeDispatcher` logging bridge for dispatcher exceptions that Uno otherwise swallows.
- Kept unobserved task exceptions observed and nonfatal; recoverable background failures remain logged without terminating Emerald.
- Unified normal shutdown for window close, macOS termination, successful host exit, and updater installation.
- Added next-launch recovery before risky host/MainPage initialization, with one dialog and a non-modal fallback panel.
- Added About → Crash Reports history with details, clipboard export, logs-folder access, GitHub reporting, and confirmed deletion.
- Added the sanitized crash-report GitHub issue template.
- Added desktop and WinAppSDK packaged crash profiles. Packaged profiles use explicit `--emerald-test=1` arguments because MSIX launch-profile environment variables are not reliably propagated.
- Kept Minecraft runtime crash handling separate.
- Detach the repeater’s `ItemsSource` in `OnNavigatedFrom`, then restores it on return. This prevents stale WinRT collection callbacks without swallowing exceptions or changing filtering logic.

## Validation

- [x] Desktop Debug application build
- [x] 16 real crash-process tests, including termination, one-report persistence, recovery, nonfatal paths, and packaged-style argument gating
- [x] Staged diff and whitespace checks
- [x] Windows MSIX/WinAppSDK packaged smoke test — requires a Windows host; Uno blocks Windows builds on this macOS development host with `UNOB0014`
- [x] Windows, macOS packaged, (and Linux Snap, if possible) manual UI validation

## Testing notes

See `docs/crash-testing.md` for the profiles and process-test instructions. Fatal profiles should be followed by the normal platform profile to verify next-launch recovery.