### PR TITLE
Add x64 Linux package publishing

### DIFF
--- a/.github/steps/install_dependencies/action.yml
+++ b/.github/steps/install_dependencies/action.yml
@@ -26,4 +26,4 @@ runs:
       if: runner.os == 'Linux' && inputs.job-platform == 'linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgtk-3-0
+        sudo apt-get install -y desktop-file-utils libgtk-3-0 lintian

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,24 +505,12 @@ jobs:
           path: ${{ github.workspace }}/Emerald-macOS-arm64-app.zip
           retention-days: 14
 
-  # Snap packages are built natively on each architecture — Uno Platform does not
-  # support cross-compilation for snap targets as of the current SDK version.
   publish-linux:
-    name: Linux Snap (${{ matrix.arch }})
+    name: Linux x64 Packages
     needs: ci-filter
     if: ${{ needs.ci-filter.outputs.run_linux == 'true' }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x64
-            runner: ubuntu-22.04
-            runtime: linux-x64
-          - arch: arm64
-            runner: ubuntu-22.04-arm
-            runtime: linux-arm64
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
@@ -535,12 +523,109 @@ jobs:
         with:
           job-platform: linux
 
-      # Snapcraft is installed after the base dependencies so that the snap daemon
-      # is ready before we invoke dotnet publish with PackageFormat=snap.
-      # core22 matches the Ubuntu 22.04 runner base used by both matrix legs.
-      # --destructive-mode is required in CI because LXD/Multipass are unavailable
-      # on single-use GitHub-hosted runners; it is safe here because the environment
-      # is ephemeral and discarded after the job completes.
+      - name: Publish Linux x64 payload and stage shared package files
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.ci-filter.outputs.package_version }}
+          PUBLIC_VERSION: ${{ needs.ci-filter.outputs.public_version }}
+          UPDATE_CHANNEL: ${{ needs.ci-filter.outputs.release_channel }}
+          RELEASE_TAG: ${{ needs.ci-filter.outputs.release_tag }}
+          COMMIT_SHA: ${{ github.sha }}
+          BUILD_TIMESTAMP_UTC: ${{ needs.ci-filter.outputs.build_timestamp_utc }}
+          ACCOUNT_PROVIDER_SECRETS_REQUIRED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          EMERALD_MSFT_CLIENT_ID: ${{ secrets.EMERALD_MSFT_CLIENT_ID }}
+          EMERALD_ELYBY_CLIENT_ID: ${{ secrets.EMERALD_ELYBY_CLIENT_ID }}
+          EMERALD_ELYBY_CLIENT_SECRET: ${{ secrets.EMERALD_ELYBY_CLIENT_SECRET }}
+          EMERALD_ELYBY_REDIRECT_URI: ${{ secrets.EMERALD_ELYBY_REDIRECT_URI }}
+        run: |
+          if [ "$ACCOUNT_PROVIDER_SECRETS_REQUIRED" = "true" ]; then
+            for secret_name in \
+              EMERALD_MSFT_CLIENT_ID \
+              EMERALD_ELYBY_CLIENT_ID \
+              EMERALD_ELYBY_CLIENT_SECRET \
+              EMERALD_ELYBY_REDIRECT_URI; do
+              if [ -z "${!secret_name}" ]; then
+                echo "Account-provider build secret is missing: $secret_name"
+                exit 1
+              fi
+            done
+          fi
+
+          scripts/linux/publish-linux-x64.sh
+
+      - name: Build and inspect Linux Debian package
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.ci-filter.outputs.package_version }}
+        run: scripts/linux/build-deb.sh
+
+      - name: Verify Linux AppDir staging
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "$GITHUB_WORKSPACE/AppDir/usr/lib/emerald/Emerald"
+          test -x "$GITHUB_WORKSPACE/AppDir/usr/bin/emerald"
+          test -f "$GITHUB_WORKSPACE/AppDir/usr/share/applications/emerald.desktop"
+          test -f "$GITHUB_WORKSPACE/AppDir/usr/share/applications/com.riversidevalley.Emerald.desktop"
+          test -f "$GITHUB_WORKSPACE/AppDir/usr/share/icons/hicolor/256x256/apps/emerald.png"
+
+      - name: Build and inspect Linux AppImage
+        shell: bash
+        env:
+          EMERALD_PACKAGE_VERSION: ${{ needs.ci-filter.outputs.package_version }}
+          EMERALD_APPIMAGE_NAME: Emerald-linux-x64.AppImage
+          APPIMAGE_BUILDER_IMAGE: appimagecrafters/appimage-builder:1.1.0
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e "EMERALD_PACKAGE_VERSION=$EMERALD_PACKAGE_VERSION" \
+            -e "EMERALD_APPIMAGE_NAME=$EMERALD_APPIMAGE_NAME" \
+            -v "$GITHUB_WORKSPACE:/github/workspace" \
+            -w /github/workspace \
+            "$APPIMAGE_BUILDER_IMAGE" \
+            bash -lc 'apt-get update && apt-get install -y squashfs-tools && appimage-builder --recipe=scripts/linux/AppImageBuilder.x64.yml --skip-test'
+
+          APPIMAGE_FILE="$(find "$GITHUB_WORKSPACE" -maxdepth 1 -name '*.AppImage' -type f -print -quit)"
+          if [ -z "$APPIMAGE_FILE" ]; then
+            echo "No AppImage file found after appimage-builder completed"
+            exit 1
+          fi
+
+          STAGED="$GITHUB_WORKSPACE/artifacts/linux/final/Emerald-linux-x64.AppImage"
+          cp "$APPIMAGE_FILE" "$STAGED"
+          chmod +x "$STAGED"
+          "$STAGED" --appimage-extract >/dev/null
+          test -x squashfs-root/AppRun
+          rm -rf squashfs-root
+
+      - name: Generate and validate Arch source recipe
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.ci-filter.outputs.package_version }}
+          RELEASE_TAG: ${{ needs.ci-filter.outputs.release_tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TARBALL="$GITHUB_WORKSPACE/artifacts/linux/final/Emerald-linux-x64.tar.gz"
+          export TARBALL_SHA256="$(sha256sum "$TARBALL" | awk '{print $1}')"
+          scripts/linux/prepare-arch-package.sh
+
+          PKGBUILD_DIR="$GITHUB_WORKSPACE/artifacts/linux/arch/pkgbuild"
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace/artifacts/linux/arch/pkgbuild \
+            archlinux:base-devel \
+            bash -lc 'useradd -m builder && chown -R builder:builder /workspace/artifacts/linux/arch && su builder -c "makepkg --printsrcinfo"' \
+            > "$PKGBUILD_DIR/.SRCINFO"
+
+          test -s "$PKGBUILD_DIR/.SRCINFO"
+          grep -Fqx "sha256sums = $TARBALL_SHA256" "$PKGBUILD_DIR/.SRCINFO"
+          grep -Fq "releases/download/${RELEASE_TAG}/Emerald-linux-x64.tar.gz" "$PKGBUILD_DIR/PKGBUILD"
+          tar -czf "$GITHUB_WORKSPACE/artifacts/linux/final/emerald-${PACKAGE_VERSION}-1-arch-source.tar.gz" \
+            -C "$PKGBUILD_DIR" PKGBUILD .SRCINFO
+
+      # Uno supports Linux Snap generation through PackageFormat=snap. Hosted
+      # CI needs destructive mode because it cannot run the usual LXD workflow.
       - name: Install Snapcraft and Multipass
         shell: bash
         run: |
@@ -550,7 +635,7 @@ jobs:
           sudo snap install snapcraft --classic
           sudo snap install multipass
 
-      - name: Publish Linux Snap (${{ matrix.arch }})
+      - name: Publish Linux x64 Snap
         shell: bash
         env:
           # Modern Snapcraft equivalent to --destructive-mode
@@ -577,7 +662,7 @@ jobs:
           dotnet publish ./Emerald/Emerald.csproj \
             -c Release \
             -f net10.0-desktop \
-            -r "${{ matrix.runtime }}" \
+            -r linux-x64 \
             -p:SelfContained=true \
             -p:PackageFormat=snap \
             -p:UnoSnapBuildProvider=none \
@@ -599,37 +684,67 @@ jobs:
             -p:EmeraldElyByClientSecret="$EMERALD_ELYBY_CLIENT_SECRET" \
             -p:EmeraldElyByRedirectUri="$EMERALD_ELYBY_REDIRECT_URI"
 
-      - name: Locate and stage snap artifact
+      - name: Locate and stage Linux Snap artifact
         id: locate
         shell: bash
         run: |
-          # Uno places the .snap in the publish output folder; find it regardless
-          # of the exact versioned filename that snapcraft generates.
-          SNAP_FILE="$(find . -name '*.snap' -not -path '*/.git/*' -type f | head -n 1)"
+          SNAP_FILE="$(find "$GITHUB_WORKSPACE/Emerald/bin/Release" -path '*/linux-x64/publish/*.snap' -type f -print -quit)"
           if [ -z "$SNAP_FILE" ]; then
             echo "No .snap file found after publish"
             exit 1
           fi
           echo "Found snap: $SNAP_FILE"
 
-          STAGED="$GITHUB_WORKSPACE/Emerald-linux-${{ matrix.arch }}.snap"
+          STAGED="$GITHUB_WORKSPACE/artifacts/linux/final/Emerald-linux-x64.snap"
           cp "$SNAP_FILE" "$STAGED"
           echo "snap_path=$STAGED" >> "$GITHUB_OUTPUT"
 
-      - name: Upload CI Linux Snap artifact (${{ matrix.arch }})
+      - name: Upload CI Linux Snap artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Emerald-linux-${{ matrix.arch }}-snap
+          name: Emerald-linux-x64-snap
           path: ${{ steps.locate.outputs.snap_path }}
           if-no-files-found: error
           retention-days: 14
 
-      - name: Upload release Linux Snap transfer artifact (${{ matrix.arch }})
+      - name: Upload CI Linux portable tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Emerald-linux-x64-tar
+          path: ${{ github.workspace }}/artifacts/linux/final/Emerald-linux-x64.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload CI Linux AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Emerald-linux-x64-appimage
+          path: ${{ github.workspace }}/artifacts/linux/final/Emerald-linux-x64.AppImage
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload CI Linux Debian artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Emerald-linux-x64-deb
+          path: ${{ github.workspace }}/artifacts/linux/final/emerald_${{ needs.ci-filter.outputs.package_version }}_amd64.deb
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload CI Linux Arch source artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Emerald-linux-x64-arch-source
+          path: ${{ github.workspace }}/artifacts/linux/final/emerald-${{ needs.ci-filter.outputs.package_version }}-1-arch-source.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload release Linux package transfer artifact
         if: ${{ needs.ci-filter.outputs.is_release_flow == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: Emerald-linux-${{ matrix.arch }}-ReleaseDraft-Snap
-          path: ${{ steps.locate.outputs.snap_path }}
+          name: Emerald-linux-x64-ReleaseDraft-Assets
+          path: ${{ github.workspace }}/artifacts/linux/final/*
           if-no-files-found: error
           retention-days: 14
 
@@ -660,16 +775,10 @@ jobs:
           name: Emerald-macOS-arm64-app
           path: release-assets/macos
 
-      - name: Download Linux x64 Snap artifact
+      - name: Download Linux x64 package assets
         uses: actions/download-artifact@v4
         with:
-          name: Emerald-linux-x64-ReleaseDraft-Snap
-          path: release-assets/linux
-
-      - name: Download Linux arm64 Snap artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: Emerald-linux-arm64-ReleaseDraft-Snap
+          name: Emerald-linux-x64-ReleaseDraft-Assets
           path: release-assets/linux
 
       - name: Build release metadata files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,20 @@ jobs:
         with:
           job-platform: linux
 
+      # The hosted Ubuntu runner has a small SSD relative to a self-contained
+      # Uno publish plus four package formats. These SDKs are not used by this
+      # job; remove them before creating the first duplicate payload archive.
+      - name: Reclaim runner disk for Linux packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Disk space before cleanup:"
+          df -h "$GITHUB_WORKSPACE"
+          sudo rm -rf -- /usr/local/lib/android /usr/share/swift /opt/ghc /opt/hostedtoolcache/CodeQL
+          docker system prune --all --force
+          echo "Disk space after cleanup:"
+          df -h "$GITHUB_WORKSPACE"
+
       - name: Publish Linux x64 payload and stage shared package files
         shell: bash
         env:
@@ -623,6 +637,20 @@ jobs:
           grep -Fq "releases/download/${RELEASE_TAG}/Emerald-linux-x64.tar.gz" "$PKGBUILD_DIR/PKGBUILD"
           tar -czf "$GITHUB_WORKSPACE/artifacts/linux/final/emerald-${PACKAGE_VERSION}-1-arch-source.tar.gz" \
             -C "$PKGBUILD_DIR" PKGBUILD .SRCINFO
+
+      - name: Reclaim staging disk before Snap packaging
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf -- \
+            "$GITHUB_WORKSPACE/AppDir" \
+            "$GITHUB_WORKSPACE/appimage-build" \
+            "$GITHUB_WORKSPACE/artifacts/linux/install-root" \
+            "$GITHUB_WORKSPACE/artifacts/linux/publish" \
+            "$GITHUB_WORKSPACE/artifacts/linux/arch"
+          docker system prune --all --force
+          echo "Disk space available for Snap packaging:"
+          df -h "$GITHUB_WORKSPACE"
 
       # Uno supports Linux Snap generation through PackageFormat=snap. Hosted
       # CI needs destructive mode because it cannot run the usual LXD workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,12 +612,13 @@ jobs:
           scripts/linux/prepare-arch-package.sh
 
           PKGBUILD_DIR="$GITHUB_WORKSPACE/artifacts/linux/arch/pkgbuild"
+          SRCINFO_TEMP="$(mktemp)"
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
-            -w /workspace/artifacts/linux/arch/pkgbuild \
-            archlinux:base-devel \
-            bash -lc 'useradd -m builder && chown -R builder:builder /workspace/artifacts/linux/arch && su builder -c "makepkg --printsrcinfo"' \
-            > "$PKGBUILD_DIR/.SRCINFO"
+            archlinux:base-devel@sha256:84cd9ef000b3cff245ec028e87965b84724f4bf1cc63fc2741ba927b88515ed6 \
+            bash -lc 'useradd --create-home builder && install -d -o builder -g builder /home/builder/pkgbuild && install -o builder -g builder /workspace/artifacts/linux/arch/pkgbuild/PKGBUILD /home/builder/pkgbuild/PKGBUILD && runuser --user builder -- makepkg --printsrcinfo --dir /home/builder/pkgbuild' \
+            | tee "$SRCINFO_TEMP"
+          mv "$SRCINFO_TEMP" "$PKGBUILD_DIR/.SRCINFO"
 
           test -s "$PKGBUILD_DIR/.SRCINFO"
           grep -Fqx "sha256sums = $TARBALL_SHA256" "$PKGBUILD_DIR/.SRCINFO"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,7 @@ jobs:
         shell: bash
         env:
           PACKAGE_VERSION: ${{ needs.ci-filter.outputs.package_version }}
+          BUILD_TIMESTAMP_UTC: ${{ needs.ci-filter.outputs.build_timestamp_utc }}
         run: scripts/linux/build-deb.sh
 
       - name: Verify Linux AppDir staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,20 +523,6 @@ jobs:
         with:
           job-platform: linux
 
-      # The hosted Ubuntu runner has a small SSD relative to a self-contained
-      # Uno publish plus four package formats. These SDKs are not used by this
-      # job; remove them before creating the first duplicate payload archive.
-      - name: Reclaim runner disk for Linux packages
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Disk space before cleanup:"
-          df -h "$GITHUB_WORKSPACE"
-          sudo rm -rf -- /usr/local/lib/android /usr/share/swift /opt/ghc /opt/hostedtoolcache/CodeQL
-          docker system prune --all --force
-          echo "Disk space after cleanup:"
-          df -h "$GITHUB_WORKSPACE"
-
       - name: Publish Linux x64 payload and stage shared package files
         shell: bash
         env:
@@ -637,20 +623,6 @@ jobs:
           grep -Fq "releases/download/${RELEASE_TAG}/Emerald-linux-x64.tar.gz" "$PKGBUILD_DIR/PKGBUILD"
           tar -czf "$GITHUB_WORKSPACE/artifacts/linux/final/emerald-${PACKAGE_VERSION}-1-arch-source.tar.gz" \
             -C "$PKGBUILD_DIR" PKGBUILD .SRCINFO
-
-      - name: Reclaim staging disk before Snap packaging
-        shell: bash
-        run: |
-          set -euo pipefail
-          rm -rf -- \
-            "$GITHUB_WORKSPACE/AppDir" \
-            "$GITHUB_WORKSPACE/appimage-build" \
-            "$GITHUB_WORKSPACE/artifacts/linux/install-root" \
-            "$GITHUB_WORKSPACE/artifacts/linux/publish" \
-            "$GITHUB_WORKSPACE/artifacts/linux/arch"
-          docker system prune --all --force
-          echo "Disk space available for Snap packaging:"
-          df -h "$GITHUB_WORKSPACE"
 
       # Uno supports Linux Snap generation through PackageFormat=snap. Hosted
       # CI needs destructive mode because it cannot run the usual LXD workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
           mv "$SRCINFO_TEMP" "$PKGBUILD_DIR/.SRCINFO"
 
           test -s "$PKGBUILD_DIR/.SRCINFO"
-          grep -Fqx "sha256sums = $TARBALL_SHA256" "$PKGBUILD_DIR/.SRCINFO"
+          grep -Fq "sha256sums = $TARBALL_SHA256" "$PKGBUILD_DIR/.SRCINFO"
           grep -Fq "releases/download/${RELEASE_TAG}/Emerald-linux-x64.tar.gz" "$PKGBUILD_DIR/PKGBUILD"
           tar -czf "$GITHUB_WORKSPACE/artifacts/linux/final/emerald-${PACKAGE_VERSION}-1-arch-source.tar.gz" \
             -C "$PKGBUILD_DIR" PKGBUILD .SRCINFO

--- a/scripts/linux/AppImageBuilder.x64.yml
+++ b/scripts/linux/AppImageBuilder.x64.yml
@@ -1,0 +1,53 @@
+version: 1
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: com.riversidevalley.Emerald
+    name: Emerald
+    icon: emerald
+    version: !ENV ${EMERALD_PACKAGE_VERSION}
+    exec: usr/lib/emerald/Emerald
+    exec_args: $@
+  runtime:
+    env:
+      APPDIR_LIBRARY_PATH: '$APPDIR/usr/lib/emerald:$APPDIR/usr/lib:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu'
+      GTK_THEME: Default
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: deb https://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse
+        key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+      - sourceline: deb https://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse
+      - sourceline: deb https://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse
+    include:
+      - libgtk-3-0
+      - libgtk-3-bin
+      - libgtk-3-common
+      - libx11-6
+      - libfontconfig1
+      - libfreetype6
+      - libgcc-s1
+      - libstdc++6
+      - libcanberra-gtk3-module
+    exclude:
+      - hicolor-icon-theme
+      - humanity-icon-theme
+  files:
+    exclude:
+      - usr/share/man
+      - usr/share/doc/*/README.*
+      - usr/share/doc/*/changelog.*
+      - usr/share/doc/*/NEWS.*
+      - usr/share/doc/*/TODO.*
+      - usr/bin/kernel-install
+      - usr/lib/kernel
+      - usr/share/bug
+      - lib/systemd
+      - etc/init.d
+
+AppImage:
+  arch: x86_64
+  file_name: !ENV ${EMERALD_APPIMAGE_NAME}
+  update-information: None
+  sign-key: None

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -47,11 +47,11 @@ CHANGELOG_DATE="$(date --date="$BUILD_TIMESTAMP_UTC" --rfc-email)"
 
 cat > "$DEB_ROOT/usr/share/lintian/overrides/emerald" <<'EOF'
 # Uno's self-contained .NET publish intentionally carries these native runtime libraries.
-emerald: embedded-library freetype [usr/lib/emerald/libSkiaSharp.so]
-emerald: embedded-library libjpeg [usr/lib/emerald/libSkiaSharp.so]
-emerald: embedded-library libpng [usr/lib/emerald/libSkiaSharp.so]
-emerald: embedded-library zlib [usr/lib/emerald/libSystem.IO.Compression.Native.so]
-emerald: unstripped-binary-or-object [usr/lib/emerald/libSkiaSharp.so]
+emerald: embedded-library freetype usr/lib/emerald/libSkiaSharp.so
+emerald: embedded-library libjpeg usr/lib/emerald/libSkiaSharp.so
+emerald: embedded-library libpng usr/lib/emerald/libSkiaSharp.so
+emerald: embedded-library zlib usr/lib/emerald/libSystem.IO.Compression.Native.so
+emerald: unstripped-binary-or-object usr/lib/emerald/libSkiaSharp.so
 EOF
 
 find "$DEB_ROOT" -type d -exec chmod 755 {} +

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -37,5 +37,5 @@ find "$DEB_ROOT" -type d -exec chmod 755 {} +
 chmod 644 "$DEB_ROOT/DEBIAN/control"
 dpkg-deb --build --root-owner-group "$DEB_ROOT" "$DEB_PATH"
 dpkg-deb --info "$DEB_PATH"
-dpkg-deb --contents "$DEB_PATH" | grep -q 'usr/bin/emerald'
+dpkg-deb --contents "$DEB_PATH" | grep 'usr/bin/emerald' >/dev/null
 lintian --fail-on error "$DEB_PATH"

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/artifacts/linux}"
 PACKAGE_VERSION="${PACKAGE_VERSION:?PACKAGE_VERSION is required}"
+BUILD_TIMESTAMP_UTC="${BUILD_TIMESTAMP_UTC:?BUILD_TIMESTAMP_UTC is required}"
 INSTALL_ROOT="$OUTPUT_ROOT/install-root"
 DEB_ROOT="$OUTPUT_ROOT/deb/root"
 FINAL_DIR="$OUTPUT_ROOT/final"
@@ -22,7 +23,7 @@ INSTALLED_SIZE="$(du -sk "$DEB_ROOT/usr" | awk '{print $1}')"
 cat > "$DEB_ROOT/DEBIAN/control" <<EOF
 Package: emerald
 Version: $PACKAGE_VERSION
-Section: games
+Section: utils
 Priority: optional
 Architecture: amd64
 Maintainer: Riverside Valley <support@riversidevalley.dev>
@@ -33,9 +34,33 @@ Description: Open-source cross-platform Minecraft launcher
  Emerald is an open-source cross-platform Minecraft launcher made with .NET.
 EOF
 
+install -d -m 755 \
+  "$DEB_ROOT/usr/share/doc/emerald" \
+  "$DEB_ROOT/usr/share/lintian/overrides"
+
+CHANGELOG_DATE="$(date --date="$BUILD_TIMESTAMP_UTC" --rfc-email)"
+{
+  printf 'emerald (%s) stable; urgency=medium\n\n' "$PACKAGE_VERSION"
+  printf '  * Automated GitHub release build.\n\n'
+  printf ' -- Riverside Valley <support@riversidevalley.dev>  %s\n' "$CHANGELOG_DATE"
+} | gzip -9n > "$DEB_ROOT/usr/share/doc/emerald/changelog.gz"
+
+cat > "$DEB_ROOT/usr/share/lintian/overrides/emerald" <<'EOF'
+# Uno's self-contained .NET publish intentionally carries these native runtime libraries.
+emerald: embedded-library freetype [usr/lib/emerald/libSkiaSharp.so]
+emerald: embedded-library libjpeg [usr/lib/emerald/libSkiaSharp.so]
+emerald: embedded-library libpng [usr/lib/emerald/libSkiaSharp.so]
+emerald: embedded-library zlib [usr/lib/emerald/libSystem.IO.Compression.Native.so]
+emerald: unstripped-binary-or-object [usr/lib/emerald/libSkiaSharp.so]
+EOF
+
 find "$DEB_ROOT" -type d -exec chmod 755 {} +
-chmod 644 "$DEB_ROOT/DEBIAN/control"
+find "$DEB_ROOT" -type f -exec chmod 644 {} +
+chmod 755 "$DEB_ROOT/usr/bin/emerald" "$DEB_ROOT/usr/lib/emerald/Emerald"
+if [ -f "$DEB_ROOT/usr/lib/emerald/createdump" ]; then
+  chmod 755 "$DEB_ROOT/usr/lib/emerald/createdump"
+fi
 dpkg-deb --build --root-owner-group "$DEB_ROOT" "$DEB_PATH"
 dpkg-deb --info "$DEB_PATH"
 dpkg-deb --contents "$DEB_PATH" | grep 'usr/bin/emerald' >/dev/null
-lintian --fail-on error "$DEB_PATH"
+lintian --show-overrides --fail-on error "$DEB_PATH"

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/artifacts/linux}"
+PACKAGE_VERSION="${PACKAGE_VERSION:?PACKAGE_VERSION is required}"
+INSTALL_ROOT="$OUTPUT_ROOT/install-root"
+DEB_ROOT="$OUTPUT_ROOT/deb/root"
+FINAL_DIR="$OUTPUT_ROOT/final"
+DEB_PATH="$FINAL_DIR/emerald_${PACKAGE_VERSION}_amd64.deb"
+
+if [ ! -d "$INSTALL_ROOT/opt/emerald" ]; then
+  echo "Install root was not found. Run scripts/linux/publish-linux-x64.sh first."
+  exit 1
+fi
+
+rm -rf "$DEB_ROOT"
+mkdir -p "$DEB_ROOT/DEBIAN" "$FINAL_DIR"
+cp -a "$INSTALL_ROOT/." "$DEB_ROOT/"
+
+INSTALLED_SIZE="$(du -sk "$DEB_ROOT/opt/emerald" "$DEB_ROOT/usr" | awk '{total += $1} END {print total}')"
+
+cat > "$DEB_ROOT/DEBIAN/control" <<EOF
+Package: emerald
+Version: $PACKAGE_VERSION
+Section: games
+Priority: optional
+Architecture: amd64
+Maintainer: Riverside Valley <support@riversidevalley.dev>
+Installed-Size: $INSTALLED_SIZE
+Depends: libgtk-3-0, libx11-6, libfontconfig1, libfreetype6, libgcc-s1, libstdc++6, libc6
+Homepage: https://github.com/RiversideValley/Emerald
+Description: Open-source cross-platform Minecraft launcher
+ Emerald is an open-source cross-platform Minecraft launcher made with .NET.
+EOF
+
+find "$DEB_ROOT" -type d -exec chmod 755 {} +
+chmod 644 "$DEB_ROOT/DEBIAN/control"
+dpkg-deb --build --root-owner-group "$DEB_ROOT" "$DEB_PATH"
+dpkg-deb --info "$DEB_PATH"
+dpkg-deb --contents "$DEB_PATH" | grep -q 'usr/bin/emerald'
+lintian --fail-on error "$DEB_PATH"

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -8,7 +8,7 @@ DEB_ROOT="$OUTPUT_ROOT/deb/root"
 FINAL_DIR="$OUTPUT_ROOT/final"
 DEB_PATH="$FINAL_DIR/emerald_${PACKAGE_VERSION}_amd64.deb"
 
-if [ ! -d "$INSTALL_ROOT/opt/emerald" ]; then
+if [ ! -d "$INSTALL_ROOT/usr/lib/emerald" ]; then
   echo "Install root was not found. Run scripts/linux/publish-linux-x64.sh first."
   exit 1
 fi
@@ -17,7 +17,7 @@ rm -rf "$DEB_ROOT"
 mkdir -p "$DEB_ROOT/DEBIAN" "$FINAL_DIR"
 cp -a "$INSTALL_ROOT/." "$DEB_ROOT/"
 
-INSTALLED_SIZE="$(du -sk "$DEB_ROOT/opt/emerald" "$DEB_ROOT/usr" | awk '{total += $1} END {print total}')"
+INSTALLED_SIZE="$(du -sk "$DEB_ROOT/usr" | awk '{print $1}')"
 
 cat > "$DEB_ROOT/DEBIAN/control" <<EOF
 Package: emerald

--- a/scripts/linux/prepare-arch-package.sh
+++ b/scripts/linux/prepare-arch-package.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/artifacts/linux}"
+PACKAGE_VERSION="${PACKAGE_VERSION:?PACKAGE_VERSION is required}"
+RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
+TARBALL_SHA256="${TARBALL_SHA256:?TARBALL_SHA256 is required}"
+REPOSITORY="${REPOSITORY:-RiversideValley/Emerald}"
+PKGBUILD_DIR="$OUTPUT_ROOT/arch/pkgbuild"
+
+rm -rf "$PKGBUILD_DIR"
+mkdir -p "$PKGBUILD_DIR"
+
+cat > "$PKGBUILD_DIR/PKGBUILD" <<EOF
+pkgname=emerald-bin
+pkgver=$PACKAGE_VERSION
+pkgrel=1
+pkgdesc='Open-source cross-platform Minecraft launcher made with .NET'
+arch=('x86_64')
+url='https://github.com/$REPOSITORY'
+license=('custom')
+depends=('gtk3' 'libx11' 'fontconfig' 'freetype2' 'glibc')
+source=('Emerald-linux-x64.tar.gz::https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG/Emerald-linux-x64.tar.gz')
+sha256sums=('$TARBALL_SHA256')
+
+package() {
+  install -dm755 "\$pkgdir/opt/emerald"
+  cp -a "\$srcdir/Emerald-linux-x64/." "\$pkgdir/opt/emerald/"
+
+  install -Dm755 /dev/stdin "\$pkgdir/usr/bin/emerald" <<'LAUNCHER'
+#!/usr/bin/env sh
+exec /opt/emerald/Emerald "\$@"
+LAUNCHER
+
+  install -Dm644 /dev/stdin "\$pkgdir/usr/share/applications/emerald.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Emerald
+Comment=Open-source cross-platform Minecraft launcher
+Exec=emerald
+Icon=emerald
+Terminal=false
+Type=Application
+Categories=Game;
+DESKTOP
+
+  install -Dm644 "\$srcdir/Emerald-linux-x64/emerald.png" "\$pkgdir/usr/share/icons/hicolor/256x256/apps/emerald.png"
+  install -Dm644 "\$srcdir/Emerald-linux-x64/LICENSE.md" "\$pkgdir/usr/share/licenses/emerald/LICENSE.md"
+}
+EOF

--- a/scripts/linux/prepare-arch-package.sh
+++ b/scripts/linux/prepare-arch-package.sh
@@ -24,12 +24,12 @@ source=('Emerald-linux-x64.tar.gz::https://github.com/$REPOSITORY/releases/downl
 sha256sums=('$TARBALL_SHA256')
 
 package() {
-  install -dm755 "\$pkgdir/opt/emerald"
-  cp -a "\$srcdir/Emerald-linux-x64/." "\$pkgdir/opt/emerald/"
+  install -dm755 "\$pkgdir/usr/lib/emerald"
+  cp -a "\$srcdir/Emerald-linux-x64/." "\$pkgdir/usr/lib/emerald/"
 
   install -Dm755 /dev/stdin "\$pkgdir/usr/bin/emerald" <<'LAUNCHER'
 #!/usr/bin/env sh
-exec /opt/emerald/Emerald "\$@"
+exec /usr/lib/emerald/Emerald "\$@"
 LAUNCHER
 
   install -Dm644 /dev/stdin "\$pkgdir/usr/share/applications/emerald.desktop" <<'DESKTOP'

--- a/scripts/linux/prepare-arch-package.sh
+++ b/scripts/linux/prepare-arch-package.sh
@@ -44,6 +44,6 @@ Categories=Game;
 DESKTOP
 
   install -Dm644 "\$srcdir/Emerald-linux-x64/emerald.png" "\$pkgdir/usr/share/icons/hicolor/256x256/apps/emerald.png"
-  install -Dm644 "\$srcdir/Emerald-linux-x64/LICENSE.md" "\$pkgdir/usr/share/licenses/emerald/LICENSE.md"
+  install -Dm644 "\$srcdir/Emerald-linux-x64/LICENSE.md" "\$pkgdir/usr/share/licenses/emerald-bin/LICENSE.md"
 }
 EOF

--- a/scripts/linux/publish-linux-x64.sh
+++ b/scripts/linux/publish-linux-x64.sh
@@ -47,6 +47,16 @@ if [ ! -x "$PUBLISH_DIR/Emerald" ]; then
   exit 1
 fi
 
+# dotnet publish may preserve executable bits on managed assemblies and assets.
+# Normalize the portable payload, then restore executable mode only where it is
+# required at runtime.
+find "$PUBLISH_DIR" -type d -exec chmod 755 {} +
+find "$PUBLISH_DIR" -type f -exec chmod 644 {} +
+chmod 755 "$PUBLISH_DIR/Emerald"
+if [ -f "$PUBLISH_DIR/createdump" ]; then
+  chmod 755 "$PUBLISH_DIR/createdump"
+fi
+
 # Include the application icon in the portable archive so the Arch recipe can
 # build a complete desktop package from the GitHub release asset alone.
 install -m644 "$PWD/Emerald/Assets/icon.png" "$PUBLISH_DIR/emerald.png"
@@ -58,13 +68,13 @@ tar -czf "$FINAL_DIR/Emerald-linux-x64.tar.gz" -C "$PUBLISH_ROOT" "Emerald-linux
 tar -tzf "$FINAL_DIR/Emerald-linux-x64.tar.gz" \
   | grep -Fx 'Emerald-linux-x64/Emerald' >/dev/null
 
-install -dm755 "$INSTALL_ROOT/opt/emerald"
-cp -a "$PUBLISH_DIR/." "$INSTALL_ROOT/opt/emerald/"
+install -dm755 "$INSTALL_ROOT/usr/lib/emerald"
+cp -a "$PUBLISH_DIR/." "$INSTALL_ROOT/usr/lib/emerald/"
 
 install -dm755 "$INSTALL_ROOT/usr/bin"
 cat > "$INSTALL_ROOT/usr/bin/emerald" <<'EOF'
 #!/usr/bin/env sh
-exec /opt/emerald/Emerald "$@"
+exec /usr/lib/emerald/Emerald "$@"
 EOF
 chmod 755 "$INSTALL_ROOT/usr/bin/emerald"
 

--- a/scripts/linux/publish-linux-x64.sh
+++ b/scripts/linux/publish-linux-x64.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_PATH="${PROJECT_PATH:-./Emerald/Emerald.csproj}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/artifacts/linux}"
+PACKAGE_VERSION="${PACKAGE_VERSION:?PACKAGE_VERSION is required}"
+PUBLIC_VERSION="${PUBLIC_VERSION:?PUBLIC_VERSION is required}"
+UPDATE_CHANNEL="${UPDATE_CHANNEL:?UPDATE_CHANNEL is required}"
+RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
+COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+BUILD_TIMESTAMP_UTC="${BUILD_TIMESTAMP_UTC:?BUILD_TIMESTAMP_UTC is required}"
+
+PUBLISH_ROOT="$OUTPUT_ROOT/publish"
+PUBLISH_DIR="$PUBLISH_ROOT/Emerald-linux-x64"
+INSTALL_ROOT="$OUTPUT_ROOT/install-root"
+APPDIR="${APPDIR:-$PWD/AppDir}"
+FINAL_DIR="$OUTPUT_ROOT/final"
+
+rm -rf "$PUBLISH_DIR" "$INSTALL_ROOT" "$APPDIR"
+mkdir -p "$PUBLISH_DIR" "$INSTALL_ROOT" "$APPDIR" "$FINAL_DIR"
+
+dotnet publish "$PROJECT_PATH" \
+  -c Release \
+  -f net10.0-desktop \
+  -r linux-x64 \
+  -p:SelfContained=true \
+  -p:PublishTrimmed=false \
+  -p:PublishSingleFile=false \
+  -p:Version="$PACKAGE_VERSION" \
+  -p:FileVersion="$PACKAGE_VERSION" \
+  -p:AssemblyVersion="$PACKAGE_VERSION" \
+  -p:InformationalVersion="$PUBLIC_VERSION" \
+  -p:EmeraldPackageVersion="$PACKAGE_VERSION" \
+  -p:EmeraldPublicVersion="$PUBLIC_VERSION" \
+  -p:EmeraldUpdateChannel="$UPDATE_CHANNEL" \
+  -p:EmeraldReleaseTag="$RELEASE_TAG" \
+  -p:EmeraldCommitSha="$COMMIT_SHA" \
+  -p:EmeraldBuildTimestampUtc="$BUILD_TIMESTAMP_UTC" \
+  -p:EmeraldMSFTClientId="${EMERALD_MSFT_CLIENT_ID:-}" \
+  -p:EmeraldElyByClientId="${EMERALD_ELYBY_CLIENT_ID:-}" \
+  -p:EmeraldElyByClientSecret="${EMERALD_ELYBY_CLIENT_SECRET:-}" \
+  -p:EmeraldElyByRedirectUri="${EMERALD_ELYBY_REDIRECT_URI:-}" \
+  -o "$PUBLISH_DIR"
+
+if [ ! -x "$PUBLISH_DIR/Emerald" ]; then
+  echo "Expected Linux executable was not found at $PUBLISH_DIR/Emerald"
+  exit 1
+fi
+
+# Include the application icon in the portable archive so the Arch recipe can
+# build a complete desktop package from the GitHub release asset alone.
+install -m644 "$PWD/Emerald/Assets/icon.png" "$PUBLISH_DIR/emerald.png"
+install -m644 "$PWD/LICENSE.md" "$PUBLISH_DIR/LICENSE.md"
+
+tar -czf "$FINAL_DIR/Emerald-linux-x64.tar.gz" -C "$PUBLISH_ROOT" "Emerald-linux-x64"
+tar -tzf "$FINAL_DIR/Emerald-linux-x64.tar.gz" | grep -qx 'Emerald-linux-x64/Emerald'
+
+install -dm755 "$INSTALL_ROOT/opt/emerald"
+cp -a "$PUBLISH_DIR/." "$INSTALL_ROOT/opt/emerald/"
+
+install -dm755 "$INSTALL_ROOT/usr/bin"
+cat > "$INSTALL_ROOT/usr/bin/emerald" <<'EOF'
+#!/usr/bin/env sh
+exec /opt/emerald/Emerald "$@"
+EOF
+chmod 755 "$INSTALL_ROOT/usr/bin/emerald"
+
+install -dm755 "$INSTALL_ROOT/usr/share/applications"
+cat > "$INSTALL_ROOT/usr/share/applications/emerald.desktop" <<'EOF'
+[Desktop Entry]
+Name=Emerald
+Comment=Open-source cross-platform Minecraft launcher
+Exec=emerald
+Icon=emerald
+Terminal=false
+Type=Application
+Categories=Game;
+EOF
+
+install -dm755 "$INSTALL_ROOT/usr/share/icons/hicolor/256x256/apps"
+install -m644 "$PUBLISH_DIR/emerald.png" "$INSTALL_ROOT/usr/share/icons/hicolor/256x256/apps/emerald.png"
+
+install -dm755 "$INSTALL_ROOT/usr/share/doc/emerald" "$INSTALL_ROOT/usr/share/licenses/emerald"
+install -m644 "$PWD/LICENSE.md" "$INSTALL_ROOT/usr/share/doc/emerald/copyright"
+install -m644 "$PWD/LICENSE.md" "$INSTALL_ROOT/usr/share/licenses/emerald/LICENSE.md"
+
+desktop-file-validate "$INSTALL_ROOT/usr/share/applications/emerald.desktop"
+
+install -dm755 "$APPDIR/usr/lib/emerald" "$APPDIR/usr/bin" "$APPDIR/usr/share/applications" "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+cp -a "$PUBLISH_DIR/." "$APPDIR/usr/lib/emerald/"
+install -m644 "$INSTALL_ROOT/usr/share/applications/emerald.desktop" "$APPDIR/usr/share/applications/emerald.desktop"
+install -m644 "$INSTALL_ROOT/usr/share/applications/emerald.desktop" "$APPDIR/usr/share/applications/com.riversidevalley.Emerald.desktop"
+install -m644 "$PUBLISH_DIR/emerald.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/emerald.png"
+
+cat > "$APPDIR/usr/bin/emerald" <<'EOF'
+#!/usr/bin/env sh
+APPDIR="${APPDIR:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}"
+export LD_LIBRARY_PATH="$APPDIR/usr/lib/emerald${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$APPDIR/usr/lib/emerald/Emerald" "$@"
+EOF
+chmod 755 "$APPDIR/usr/bin/emerald"

--- a/scripts/linux/publish-linux-x64.sh
+++ b/scripts/linux/publish-linux-x64.sh
@@ -53,7 +53,10 @@ install -m644 "$PWD/Emerald/Assets/icon.png" "$PUBLISH_DIR/emerald.png"
 install -m644 "$PWD/LICENSE.md" "$PUBLISH_DIR/LICENSE.md"
 
 tar -czf "$FINAL_DIR/Emerald-linux-x64.tar.gz" -C "$PUBLISH_ROOT" "Emerald-linux-x64"
-tar -tzf "$FINAL_DIR/Emerald-linux-x64.tar.gz" | grep -qx 'Emerald-linux-x64/Emerald'
+# Do not use grep -q here: with pipefail it exits early after a match, leaving
+# tar to report a broken stdout pipe even though the archive is valid.
+tar -tzf "$FINAL_DIR/Emerald-linux-x64.tar.gz" \
+  | grep -Fx 'Emerald-linux-x64/Emerald' >/dev/null
 
 install -dm755 "$INSTALL_ROOT/opt/emerald"
 cp -a "$PUBLISH_DIR/." "$INSTALL_ROOT/opt/emerald/"


### PR DESCRIPTION
## Summary
- forward-ports Linux packaging from the obsolete branch onto current main
- publishes x64 Snap, portable tarball, Debian package, AppImage, and Arch source recipe
- preserves current account-provider build-secret handling

## Validation
- `dotnet build Emerald.slnx --no-restore` (0 errors)
- cross-target Linux payload and staging verification
- workflow YAML, shell syntax, and Arch recipe checks